### PR TITLE
feat: Created Doctype Size Chart

### DIFF
--- a/versa_system/versa_system/doctype/size_chart/size_chart.js
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Size Chart", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/versa_system/versa_system/doctype/size_chart/size_chart.json
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.json
@@ -1,0 +1,65 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:{SC}-{DD}-{MM}-{YY}",
+ "creation": "2024-05-31 12:50:09.002053",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "length",
+  "width",
+  "radius",
+  "dimension"
+ ],
+ "fields": [
+  {
+   "fieldname": "length",
+   "fieldtype": "Float",
+   "label": "Length",
+   "precision": "2"
+  },
+  {
+   "fieldname": "width",
+   "fieldtype": "Float",
+   "label": "Width",
+   "precision": "2"
+  },
+  {
+   "fieldname": "radius",
+   "fieldtype": "Float",
+   "label": "Radius",
+   "precision": "2"
+  },
+  {
+   "fieldname": "dimension",
+   "fieldtype": "Float",
+   "label": "Dimension",
+   "precision": "2"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-05-31 13:21:03.887461",
+ "modified_by": "Administrator",
+ "module": "Versa System",
+ "name": "Size Chart",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/versa_system/versa_system/doctype/size_chart/size_chart.py
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SizeChart(Document):
+	pass

--- a/versa_system/versa_system/doctype/size_chart/test_size_chart.py
+++ b/versa_system/versa_system/doctype/size_chart/test_size_chart.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSizeChart(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
Create Doctype Size Chart.

## Analysis and design (optional)
Create Master DocType "Size Chart",It should contain the following data:
Length(float)
Width(float)
Radius(float)
Dimension(float)

## Solution description
Created Doctype Size Chart.

## Output screenshots (optional)
![Screenshot from 2024-05-31 13-43-45](https://github.com/efeoneAcademy/versa_system/assets/117623626/84a2be37-87c1-42fc-a2ff-5a6e96defe8f)

## Areas affected and ensured
New Feature

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
