### PR TITLE
feat: Created DocType Material Type

### DIFF
--- a/versa_system/versa_system/doctype/material_type/material_type.js
+++ b/versa_system/versa_system/doctype/material_type/material_type.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Material Type", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/versa_system/versa_system/doctype/material_type/material_type.json
+++ b/versa_system/versa_system/doctype/material_type/material_type.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:material_type",
+ "creation": "2024-05-31 12:15:01.323213",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "material_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "material_type",
+   "fieldtype": "Data",
+   "label": "Material Type ",
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-05-31 13:11:59.382422",
+ "modified_by": "Administrator",
+ "module": "Versa System",
+ "name": "Material Type",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/versa_system/versa_system/doctype/material_type/material_type.py
+++ b/versa_system/versa_system/doctype/material_type/material_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class MaterialType(Document):
+	pass

--- a/versa_system/versa_system/doctype/material_type/test_material_type.py
+++ b/versa_system/versa_system/doctype/material_type/test_material_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestMaterialType(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
 Create Doctype Material Type .

## Analysis and design (optional)
Create Master DocType "Material Type", it should contain the following data:
Material Type (Data)

## Solution description
Created Doctype Material Type

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/cd2e1c5c-0aee-4905-b0e1-599d2e4763fc)



## Areas affected and ensured
New Feature

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?

  - Mozilla Firefox

