### PR TITLE
fix: Renamed DocType to Feasibility Property Check

### DIFF
--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -2,7 +2,7 @@
  {
   "docstatus": 0,
   "doctype": "Workflow",
-  "document_type": "Fesibility Property Check",
+  "document_type": "Feasibility Property Check",
   "is_active": 1,
   "modified": "2024-06-03 10:50:22.214351",
   "name": "Feasibility",

--- a/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.js
+++ b/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Fesibility Property Check", {
+// frappe.ui.form.on("Feasibility Property Check", {
 // 	refresh(frm) {
 
 // 	},

--- a/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.json
+++ b/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.json
@@ -29,7 +29,7 @@
  "modified": "2024-06-03 10:32:59.290849",
  "modified_by": "Administrator",
  "module": "Versa System",
- "name": "Fesibility Property Check",
+ "name": "Feasibility Property Check",
  "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [

--- a/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.py
+++ b/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class FesibilityPropertyCheck(Document):
+class FeasibilityPropertyCheck(Document):
 	pass

--- a/versa_system/versa_system/doctype/feasibility_property_check/test_feasibility_property_check.py
+++ b/versa_system/versa_system/doctype/feasibility_property_check/test_feasibility_property_check.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestFesibilityPropertyCheck(FrappeTestCase):
+class TestFeasibilityPropertyCheck(FrappeTestCase):
 	pass


### PR DESCRIPTION
## Issue description
Name of DocType Fesibility Property Check is wrong

## Solution description
Renamed the DocType to Feasibility Property Check

## Output screenshots
![image](https://github.com/efeoneAcademy/versa_system/assets/117906220/06891ec9-27f6-4cc4-b2d6-e0973e3c8e78)

## Areas affected and ensured
DocType
- Fesibility Check (Renamed)

## Is there any existing behavior change of other features due to this code change?
Yes, A DocType renamed so it should be edited wherever referenced

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
