### PR TITLE
feat: New Feature Button From Lead To Quotation Form

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -28,7 +28,7 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {"Lead" : "public/js/lead.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
@@ -232,7 +232,6 @@ app_license = "mit"
 fixtures = [
     {"dt":"Role", "filters":[["name", "=", "Manufacturing  User"]]},
     {"dt":"Workflow","filters":[["name","in",["Feasibility", "Quotation Approval", "Mockup Design Approval"]]]},
-    {"dt":"Property Setter", "filters":[["module", "=", "Versa System"]]},
     {"dt":"Workflow State","filters":[["name","in",["sent to customer"]]]},
     {"dt":"Workflow Action Master","filters":[["name","in",["send to customer"]]]},
 ]

--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -1,0 +1,17 @@
+frappe.ui.form.on('Lead', {
+  refresh: function(frm) {
+    frm.add_custom_button(__('New Quotation'), function() {
+      frappe.model.open_mapped_doc({
+          method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_quotation',
+          frm : frm
+        });
+    }, __('Create'));
+
+    setTimeout(() => {
+      frm.remove_custom_button('Quotation', 'Create');
+      frm.remove_custom_button('Customer', 'Create');
+      frm.remove_custom_button('Prospect', 'Create');
+      frm.remove_custom_button('Opportunity', 'Create');
+    }, 10);
+  }
+});

--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -1,0 +1,19 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def map_lead_to_quotation(source_name, target_doc=None):
+    def set_missing_values(source, target):
+        target.quotation_to = "Lead"
+
+    target_doc = get_mapped_doc("Lead", source_name,
+        {
+            "Lead": {
+                "doctype": "Quotation",
+                "field_map": {
+                    "name":"party_name"
+                },
+            },
+
+        }, target_doc, set_missing_values)
+    return target_doc


### PR DESCRIPTION
## Feature description
New Feature Button From Lead To Quotation Form

## Analysis and design (optional)
Introduced A Group Button Where There Exist A New Quotation Drop Down While Clicking In It Lead To Quotation Form

## Solution description
If Create == New Quotation
then
get_mapped_doc == Quotation.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/a6455ec3-cd4e-441c-8baf-10697e29b7ea)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/e2285b09-267b-432f-b048-4bb65bc898e4)


## Areas affected and ensured
New Feature

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
