### PR TITLE
feat: Adding a Feature that automatically fetch data from Lead to Fea…

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -28,7 +28,7 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {"Lead" : "public/js/lead.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
@@ -230,4 +230,6 @@ app_license = "mit"
 fixtures = [
     {"dt":"Role", "filters":[["name", "=", "Manufacturing  User"]]},
     {"dt":"Workflow","filters":[["name","in",["Feasibility"]]]},
+    # {"dt":"workflow_state","filters":[["name","in",[Draft]]]},
+    # {"dt":"workflow Action Master","filters":[["name"]]}
 ]

--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -1,0 +1,28 @@
+// In lead_custom_script.js
+
+frappe.ui.form.on("Lead", {
+    refresh: function(frm) {
+        frm.add_custom_button(__("Feasibility Property Check"), function() {
+            frappe.call({
+                method: "versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_feasibility_check",
+                args: {
+                    source_name: frm.doc.name
+                },
+                callback: function(r) {
+                    if (r.message) {
+                        frappe.set_route("Form", "Feasibility Property Check", r.message);
+                    }
+                }
+            });
+        }, __("Create"));
+    }
+});
+
+
+// frappe.ui.form.on('Lead', {
+//     refresh: function(frm) {
+//         frm.add_custom_button(__('Feasibility Check'), function() {
+//
+//         }, __('Create'));
+//     }
+// });

--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -1,0 +1,34 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+# Method to create a Feasibility Property Check from a Lead
+def map_lead_to_feasibility_check(source_name, target_doc=None):
+    def set_missing_values(source, target):
+        pass
+
+    target_doc = get_mapped_doc("Lead", source_name,
+        {
+            "Lead": {
+                "doctype": "Feasibility Property Check",
+                "field_map": {
+                },
+            },
+            "Properties Table": {
+                "doctype": "Feasibility Check",
+                "field_map": {
+                    'item_type': 'item_type',
+                    'meterial_type': 'meterial_type',
+                    'design': 'design',
+                    'model': 'model',
+                    'brand': 'brand',
+                    'size_chart': 'size_chart',
+                    'rate_range': 'rate_range'
+                },
+            },
+        }, target_doc, set_missing_values)
+
+    target_doc.submit()
+    frappe.msgprint(('Feasibility Check created'), indicator="green", alert=1)
+    frappe.db.commit()
+    return target_doc.name

--- a/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.js
+++ b/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.js
@@ -6,3 +6,13 @@
 
 // 	},
 // });
+frappe.ui.form.on('Lead', {
+    refresh: function(frm) {
+        frm.add_custom_button(__('Create Feasibility Property Check'), function() {
+            frappe.model.open_mapped_doc({
+                method: 'versa_system.versa_system.doctype.feasibility_property_check.feasibility_property_check.map_lead_to_feasibility_check',
+                frm: frm
+            });
+        }, __('Create'));
+    }
+});


### PR DESCRIPTION
…sibility Property Check

## Feature description
Adding a Feature that automatically fetch data from Lead to Feasibility Property Check

## Analysis and design (optional)
Get the Data From the Child table,"Properties table" to "Feasibility property Check" Automatically.

## Solution description
Created a map_lead_to_feasibility_check method in lead.py that fetches the data and this function is called in lead.js

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/bae0833d-da9a-4cb8-b1af-d96e358cc3a6)


## Areas affected and ensured
New Feature.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
