### PR TITLE
feat: New Feature Button from Lead to Feasibility Property Check

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -1,3 +1,4 @@
+
 frappe.ui.form.on('Lead', {
   refresh: function(frm) {
     frm.add_custom_button(__('New Quotation'), function() {
@@ -13,5 +14,20 @@ frappe.ui.form.on('Lead', {
       frm.remove_custom_button('Prospect', 'Create');
       frm.remove_custom_button('Opportunity', 'Create');
     }, 10);
+
+    frm.add_custom_button(__("Feasibility Property Check"), function() {
+        frappe.call({
+            method: "versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_feasibility_check",
+            args: {
+                source_name: frm.doc.name
+            },
+            callback: function(r) {
+                if (r.message) {
+                    frappe.set_route("Form", "Feasibility Property Check", r.message);
+                }
+            }
+        });
+    }, __("Create"));
+
   }
 });

--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -5,7 +5,6 @@ from frappe.model.mapper import get_mapped_doc
 def map_lead_to_quotation(source_name, target_doc=None):
     def set_missing_values(source, target):
         target.quotation_to = "Lead"
-
     target_doc = get_mapped_doc("Lead", source_name,
         {
             "Lead": {
@@ -17,3 +16,43 @@ def map_lead_to_quotation(source_name, target_doc=None):
 
         }, target_doc, set_missing_values)
     return target_doc
+
+@frappe.whitelist()
+def map_lead_to_feasibility_check(source_name, target_doc=None):
+    '''
+        Method : Method to map a Lead to a Feasibility Property Check document
+
+        Args :
+         source_name : The name of the Lead document to be mapped
+         target_doc : The target document to which the Lead and its Properties Table should be mapped.
+
+        Output :  Name of the newly created Feasibility Property Check document.
+    '''
+    def set_missing_values(source, target):
+        pass
+
+    target_doc = get_mapped_doc("Lead", source_name,
+        {
+            "Lead": {
+                "doctype": "Feasibility Property Check",
+                "field_map": {
+                },
+            },
+            "Properties Table": {
+                "doctype": "Feasibility Check",
+                "field_map": {
+                    'item_type': 'item_type',
+                    'meterial_type': 'meterial_type',
+                    'design': 'design',
+                    'model': 'model',
+                    'brand': 'brand',
+                    'size_chart': 'size_chart',
+                    'rate_range': 'rate_range'
+                },
+            },
+        }, target_doc, set_missing_values)
+
+    target_doc.submit()
+    frappe.msgprint(('Feasibility Check created'), indicator="green", alert=1)
+    frappe.db.commit()
+    return target_doc.name


### PR DESCRIPTION
## Feature description
Automatically map data from the Properties Table child table in a Lead document to a Feasibility Property Check document.

## Analysis and design (optional)
Get the Data From the Child table,"Properties table" to "Feasibility property Check" Automatically.

## Solution description
Created the Button from Lead to Feasibility property Check

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/594b8147-7076-4153-9dd5-ef0613a64d99)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/0af55903-db20-4c5d-956f-869580009fbd)


## Areas affected and ensured
New Feature

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
- Mozilla Firefox
