### PR TITLE
feat: Creating Mockup Design from Lead doctype

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -13,5 +13,23 @@ frappe.ui.form.on('Lead', {
       frm.remove_custom_button('Prospect', 'Create');
       frm.remove_custom_button('Opportunity', 'Create');
     }, 10);
+
+    frm.add_custom_button(__('Mockup Design'), function() {
+      /**
+     * created a new custom button Mockup Design in lead doc
+     */
+        frappe.call({
+            method: "versa_system.versa_system.custom_scripts.lead.lead.custom_button_for_mockup_design",
+            args: {
+                source_name: frm.doc.name
+            },
+            callback: function(r) {
+                if (r.message) {
+                    frappe.set_route("Form", "Mockup Design", r.message);
+                }
+            }
+        });
+    }, __('Create'));
+
   }
 });

--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -17,3 +17,36 @@ def map_lead_to_quotation(source_name, target_doc=None):
 
         }, target_doc, set_missing_values)
     return target_doc
+
+@frappe.whitelist()
+def custom_button_for_mockup_design(source_name, target_doc=None):
+    """method to get Mockup Design for custom button in lead doctype by using mapdoc.
+           output: method to get fetched lead and properties table data into Mockup Design doc.
+    """
+    def set_missing_values(source, target):
+        pass
+
+    target_doc = get_mapped_doc("Lead", source_name,
+    {
+        "Lead": {
+            "doctype": "Mockup Design",
+            "field_map": {
+            },
+        },
+         "Properties Table": {
+                "doctype": "Properties Table",
+                 "field_map": {
+                    'item_type': 'item_type',
+                    'meterial_type': 'meterial_type',
+                    'design': 'design',
+                    'model': 'model',
+                    'brand': 'brand',
+                    'size_chart': 'size_chart',
+                    'rate_range': 'rate_range'
+                },
+            },
+    }, target_doc, set_missing_values)
+
+    target_doc.insert()
+    frappe.db.commit()
+    return target_doc.name


### PR DESCRIPTION
## Feature description
Creating a Mockup Design From Lead.

## Analysis and design (optional)
Button Forward to the Mockup Design DocType.

## Solution description
Mockup Design created in lead .

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/480720da-84bf-4f51-897e-6dc006958aa6)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/7ec8358c-0e55-4596-a525-79a829f86b0a)


## Areas affected and ensured
New Feature

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
