### PR TITLE
fix:Changed the Naming series and Added a New Field for the DocType Sizechart

### DIFF
--- a/versa_system/versa_system/doctype/size_chart/size_chart.json
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.json
@@ -1,11 +1,12 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:{SC}-{DD}-{MM}-{YY}",
+ "autoname": "format:{SC}-{DD}{MM}{YY}{####}",
  "creation": "2024-05-31 12:50:09.002053",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "uom",
   "length",
   "width",
   "radius",
@@ -35,11 +36,17 @@
    "fieldtype": "Float",
    "label": "Dimension",
    "precision": "2"
+  },
+  {
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "label": "Unit of Measure",
+   "options": "UOM"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-05-31 13:21:03.887461",
+ "modified": "2024-06-05 12:50:07.825650",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Size Chart",


### PR DESCRIPTION

## Issue description
Incorrect Naming Series and Absence of Unit of Measure field for DocType Sizechart

## Solution description
Changed the Naming Series and Added Unit of Measure Field

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/8ed21fff-ff94-4c0d-bb4a-b2f2178ab240)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/d75ba52a-4a47-447f-b819-ded52ac061f0)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
