### PR TITLE
fix: Naming series of design DocType

### DIFF
--- a/versa_system/versa_system/doctype/design/design.json
+++ b/versa_system/versa_system/doctype/design/design.json
@@ -1,11 +1,12 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:item_type",
+ "autoname": "field:design_name",
  "creation": "2024-05-31 12:43:48.070371",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "design_name",
   "item_type",
   "model",
   "image"
@@ -15,8 +16,7 @@
    "fieldname": "item_type",
    "fieldtype": "Link",
    "label": "Item Type",
-   "options": "Item Type",
-   "unique": 1
+   "options": "Item Type"
   },
   {
    "fieldname": "image",
@@ -28,11 +28,17 @@
    "fieldtype": "Link",
    "label": "Model",
    "options": "Model"
+  },
+  {
+   "fieldname": "design_name",
+   "fieldtype": "Data",
+   "label": "Design Name",
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-03 12:25:50.370967",
+ "modified": "2024-06-05 14:15:13.251179",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design",


### PR DESCRIPTION
## Issue description
Need to change the Naming Series of Design DocType.

## Solution description
Changed the naming series of Design DocType .

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/fd010a91-b9e9-400c-b75b-91dcf01d8784)
.
## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
