### PR TITLE
fix: Changed Buttons to only Map data and not Create

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -1,12 +1,6 @@
 
 frappe.ui.form.on('Lead', {
   refresh: function(frm) {
-    frm.add_custom_button(__('New Quotation'), function() {
-      frappe.model.open_mapped_doc({
-          method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_quotation',
-          frm : frm
-        });
-    }, __('Create'));
 
     setTimeout(() => {
       frm.remove_custom_button('Quotation', 'Create');
@@ -15,19 +9,26 @@ frappe.ui.form.on('Lead', {
       frm.remove_custom_button('Opportunity', 'Create');
     }, 10);
 
-    frm.add_custom_button(__("Feasibility Property Check"), function() {
-        frappe.call({
-            method: "versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_feasibility_check",
-            args: {
-                source_name: frm.doc.name
-            },
-            callback: function(r) {
-                if (r.message) {
-                    frappe.set_route("Form", "Feasibility Property Check", r.message);
-                }
-            }
+    frm.add_custom_button(__('New Quotation'), function() {
+      frappe.model.open_mapped_doc({
+          method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_quotation',
+          frm : frm
         });
-    }, __("Create"));
+    }, __('Create'));
+
+    frm.add_custom_button(__('Feasibility Property Check'), function() {
+      frappe.model.open_mapped_doc({
+          method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_feasibility_check',
+          frm : frm
+        });
+    }, __('Create'));
+
+    frm.add_custom_button(__('Mockup Design'), function() {
+      frappe.model.open_mapped_doc({
+          method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_mockup_design',
+          frm : frm
+        });
+    }, __('Create'));
 
   }
 });

--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -52,7 +52,35 @@ def map_lead_to_feasibility_check(source_name, target_doc=None):
             },
         }, target_doc, set_missing_values)
 
-    target_doc.submit()
-    frappe.msgprint(('Feasibility Check created'), indicator="green", alert=1)
-    frappe.db.commit()
-    return target_doc.name
+    return target_doc
+
+@frappe.whitelist()
+def map_lead_to_mockup_design(source_name, target_doc=None):
+    """method to get Mockup Design for custom button in lead doctype by using mapdoc.
+       output: data from lead is mapped to a new mockup design document
+    """
+    def set_missing_values(source, target):
+        pass
+
+    target_doc = get_mapped_doc("Lead", source_name,
+    {
+        "Lead": {
+            "doctype": "Mockup Design",
+            "field_map": {
+            },
+        },
+         "Properties Table": {
+                "doctype": "Properties Table",
+                 "field_map": {
+                    'item_type': 'item_type',
+                    'meterial_type': 'meterial_type',
+                    'design': 'design',
+                    'model': 'model',
+                    'brand': 'brand',
+                    'size_chart': 'size_chart',
+                    'rate_range': 'rate_range'
+                },
+            },
+    }, target_doc, set_missing_values)
+
+    return target_doc


### PR DESCRIPTION
## Issue description
Create  On Clicking Button Rather Than Map

## Analysis and design (optional)
Mapped to New Form while Clicking On Button

## Solution description
if onclick_create == get_mapped_doc ().

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/b87794b1-196b-481b-bbeb-b8717f8689c5)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/94e5e79b-3a47-4761-a72d-ccad1f7aab3f).

## Areas affected and ensured
Changed Button in Lead

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
