### PR TITLE
fix: item type unique in properties table removed

### DIFF
--- a/versa_system/versa_system/doctype/properties_table/properties_table.json
+++ b/versa_system/versa_system/doctype/properties_table/properties_table.json
@@ -24,8 +24,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Item Type",
-   "options": "Item Type",
-   "unique": 1
+   "options": "Item Type"
   },
   {
    "fieldname": "material_type",
@@ -97,7 +96,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-04 15:48:14.470168",
+ "modified": "2024-06-06 12:15:43.070073",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Properties Table",


### PR DESCRIPTION
## Issue description
Need to Remove Item Type unique in Properties Table.

## Solution description
Item Type unique in Properties Table is Removed

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/d6f3779a-195c-4091-aaab-2d990323d45c)


## Areas affected and ensured
No

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  