### PR TITLE
chor: Set Image Field

### DIFF
--- a/versa_system/versa_system/doctype/design/design.json
+++ b/versa_system/versa_system/doctype/design/design.json
@@ -9,6 +9,7 @@
   "design_name",
   "item_type",
   "model",
+  "column_break_dsww",
   "image"
  ],
  "fields": [
@@ -34,11 +35,15 @@
    "fieldtype": "Data",
    "label": "Design Name",
    "unique": 1
+  },
+  {
+   "fieldname": "column_break_dsww",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-05 14:15:13.251179",
+ "modified": "2024-06-06 12:16:54.718751",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design",

--- a/versa_system/versa_system/doctype/final_design/final_design.json
+++ b/versa_system/versa_system/doctype/final_design/final_design.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "from_lead",
+  "column_break_edmg",
   "image"
  ],
  "fields": [
@@ -19,11 +20,15 @@
    "fieldname": "image",
    "fieldtype": "Attach",
    "label": "Image"
+  },
+  {
+   "fieldname": "column_break_edmg",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-05 16:15:40.880195",
+ "modified": "2024-06-06 12:18:56.263928",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Final Design",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -8,6 +8,7 @@
  "field_order": [
   "from_lead",
   "properties",
+  "column_break_xuvm",
   "image"
  ],
  "fields": [
@@ -27,11 +28,15 @@
    "fieldtype": "Table",
    "label": "Properties",
    "options": "Properties Table"
+  },
+  {
+   "fieldname": "column_break_xuvm",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-06 09:50:30.603965",
+ "modified": "2024-06-06 12:18:39.184295",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",


### PR DESCRIPTION
## Chor description
Image Field On Wrong Side.

## Analysis and design (optional)
Setting Image Field.

## Solution description
Set Image Field In The Right Side.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/992a3dbb-10a2-46a4-bca8-701ac6cba9b6).
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/5127eb5d-8a3e-4293-9a33-7b5ed0c7473e)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/8569baa2-726a-4646-9641-6231b5fdc87d)


## Areas affected and ensured
Nothing.

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
