### PR TITLE
feat: Add Final Design button to Approved Quotation

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -28,7 +28,7 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-doctype_js = {"Lead" : "public/js/lead.js"}
+doctype_js = {"Lead" : "public/js/lead.js","Quotation" : "public/js/quotation.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/versa_system/public/js/quotation.js
+++ b/versa_system/public/js/quotation.js
@@ -1,0 +1,25 @@
+//
+//     frappe.ui.form.on('Quotation', {
+//     refresh: function(frm) {
+//         frm.add_custom_button(__('Final Design'), function() {
+//             frappe.model.open_mapped_doc({
+//                 method: 'versa_system.versa_system.custom_scripts.quotation.quotation.',
+//                 frm: frm
+//             });
+//         }, __('Create'))
+//     }
+// });
+
+
+frappe.ui.form.on('Quotation', {
+    refresh: function(frm) {
+        if (!frm.is_new() && frm.doc.workflow_state === 'Approved') {
+            frm.add_custom_button(__('Final Design'), function() {
+                frappe.model.open_mapped_doc({
+                    method: 'versa_system.versa_system.custom_scripts.quotation.quotation.map_quotation_to_final_design',
+                    frm: frm
+                });
+            }, __('Create'));
+        }
+    }
+});

--- a/versa_system/versa_system/custom_scripts/quotation/quotation.py
+++ b/versa_system/versa_system/custom_scripts/quotation/quotation.py
@@ -1,0 +1,32 @@
+
+
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def map_quotation_to_final_design(source_name, target_doc=None):
+    '''
+        Method: Method to map a Quotation to a Final Design document.
+
+        Args:
+         source_name: The name of the Quotation document to be mapped.
+         target_doc: The target document to which the Quotation should be mapped.
+
+        Output: Name of the newly created Final Design document.
+    '''
+    def set_missing_values(source, target):
+        pass
+
+    target_doc = get_mapped_doc("Quotation", source_name,
+        {
+            "Quotation": {
+                "doctype": "Final Design",
+                "field_map": {
+                    'from_lead': 'from_lead',  
+
+                },
+            },
+
+        }, target_doc, set_missing_values)
+
+    return target_doc


### PR DESCRIPTION
## Feature description
Add a "Final Design" button to approved Quotation.

## Analysis and design (optional)
Updating the button display in the JavaScript and handling Quotation mapping to Final Design documents on the server side.

## Solution description
Checks if the Quotation is approved and adds the "Final Design" button accordingly, then maps it to a Final Design document.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/f2edc385-3f01-4896-99cc-50d2bb515a04)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/3f81b1c2-a68b-4fdd-a5dd-5867eea0742e)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/51fdf1b9-08ff-4f3e-9f51-97bdcba05a6e)


## Areas affected and ensured
New Feature.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
