### PR TITLE
feat: set filter on model in properties table

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -30,5 +30,27 @@ frappe.ui.form.on('Lead', {
         });
     }, __('Create'));
 
+    set_model_query(frm)
+
   }
 });
+
+frappe.ui.form.on("Properties Table", {
+  item_type: function(frm, cdt, cdn) {
+    set_model_query(frm)
+  }
+})
+
+function set_model_query(frm) {
+  /*
+  * Function sets filter on Model field in Properties Table based on selected Item Type
+  */
+  frm.fields_dict["custom_property_table"].grid.get_field("model").get_query = function(doc, cdt, cdn) {
+      var child = locals[cdt][cdn];
+      return {
+          filters:[
+              ["item_type", "=", child.item_type]
+          ]
+      }
+  }
+}


### PR DESCRIPTION
## Feature description
Filtering Model in Properties Table based on selected Item Type

## Analysis and design
Set filter to the Model field inside Properties Table in Lead

## Solution description
Added a filter for model field in Properties Table in Lead and set it during refresh and change of item type in the table rows

## Output screenshots
![image](https://github.com/efeoneAcademy/versa_system/assets/91651425/69881af6-0540-457f-9b2c-b8b9f2c0a096)

## Areas affected and ensured
Lead

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
