### PR TITLE
feat : Properties Table of Mockup Design , Feasibility Check and Fina…

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.json
+++ b/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.json
@@ -14,7 +14,8 @@
    "fieldname": "properties",
    "fieldtype": "Table",
    "label": "Properties",
-   "options": "Feasibility Check"
+   "options": "Feasibility Check",
+   "read_only": 1
   },
   {
    "fieldname": "from_lead",
@@ -26,7 +27,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-03 10:32:59.290849",
+ "modified": "2024-06-07 10:23:38.511565",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Property Check",

--- a/versa_system/versa_system/doctype/final_design/final_design.json
+++ b/versa_system/versa_system/doctype/final_design/final_design.json
@@ -31,18 +31,20 @@
    "fieldname": "properties_table",
    "fieldtype": "Table",
    "label": "Properties Table",
-   "options": "Properties Table"
+   "options": "Properties Table",
+   "read_only": 1
   },
   {
    "fieldname": "quotation_items",
    "fieldtype": "Table",
    "label": "Quotation Items",
-   "options": "Quotation Item"
+   "options": "Quotation Item",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-06 15:33:35.287753",
+ "modified": "2024-06-07 10:26:23.097611",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Final Design",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -27,7 +27,8 @@
    "fieldname": "properties",
    "fieldtype": "Table",
    "label": "Properties",
-   "options": "Properties Table"
+   "options": "Properties Table",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_xuvm",
@@ -37,7 +38,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-06 14:06:12.817928",
+ "modified": "2024-06-07 10:25:22.285751",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",


### PR DESCRIPTION
…l Design is Editable

## Feature description
Properties Table Under the Doctype From Lead Is Editable.

## Analysis and design (optional)
Properties Table Of Mock up Design , Feasibility Check and Final Design Need to Kept as Read only

## Solution description
Properties Table Of Mock up Design , Feasibility Check and Final Design are Kept as Read only

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/79e7070c-ff68-45f4-b9bb-7c557bc32bb6)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/c18dbe4d-e5f1-4ccc-911f-4abf0a7813ae)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/0e52ea50-a053-4982-8e57-e2dcfa0ceb68)


## Areas affected and ensured
Doctype - Mockup Design , Final Design , Feasibiliy Check

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
