### PR TITLE
feat:Get data from lead to child table in Feasibility Property Check …

### DIFF
--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -84,3 +84,22 @@ def map_lead_to_mockup_design(source_name, target_doc=None):
     }, target_doc, set_missing_values)
 
     return target_doc
+@frappe.whitelist()
+def get_lead_properties(lead_name):
+    lead = frappe.get_doc("Lead", lead_name)
+    if not lead:
+        frappe.throw(_("Lead not found"))
+
+    custom_property_table = []
+    for item in lead.custom_property_table:
+        custom_property_table.append({
+            'item_type': item.item_type,
+            'material_type': item.material_type,
+            'design': item.design,
+            'model': item.model,
+            'brand': item.brand,
+            'size_chart': item.size_chart,
+            'colour': item.colour,
+        })
+
+    return custom_property_table

--- a/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.js
+++ b/versa_system/versa_system/doctype/feasibility_property_check/feasibility_property_check.js
@@ -1,8 +1,31 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
+frappe.ui.form.on('Feasibility Property Check', {
+    from_lead: function(frm) {
+        if (frm.doc.from_lead) {
+            frappe.call({
+                method: 'versa_system.versa_system.custom_scripts.lead.lead.get_lead_properties',
+                args: {
+                    lead_name: frm.doc.from_lead
+                },
+                callback: function(r) {
+                    console.log('Response received:', r);
+                    if (r.message) {
+                        frm.clear_table("properties");
 
-// frappe.ui.form.on("Feasibility Property Check", {
-// 	refresh(frm) {
+                        r.message.forEach(function(item) {
+                            var row = frm.add_child("properties");
+                            row.item_type = item.item_type;
+                            row.material_type = item.material_type;
+                            row.design = item.design;
+                            row.model = item.model;
+                            row.brand = item.brand;
+                            row.size_chart = item.size_chart;
+                            row.colour = item.colour;
+                        });
 
-// 	},
-// });
+                        frm.refresh_field("properties");
+                    }
+                }
+            });
+        }
+    }
+});


### PR DESCRIPTION
…Doctype

## Feature description
To get data from the Lead in to child table.

## Analysis and design (optional)
Get Data from the Lead in DocType "Feasibility Property Check":
When we select a lead in feasibility property check,It should automatically fill the child table

## Solution description
Mapped data from Lead to Feasibility Property Check.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
DocType-Feasibility Property Check.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
