### PR TITLE
feat: Get data from the Lead in to child table in Mockup Design.

### DIFF
--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.model.mapper import get_mapped_doc
+from frappe import _
 
 @frappe.whitelist()
 def map_lead_to_quotation(source_name, target_doc=None):
@@ -84,3 +85,26 @@ def map_lead_to_mockup_design(source_name, target_doc=None):
     }, target_doc, set_missing_values)
 
     return target_doc
+
+@frappe.whitelist()
+def get_lead_properties(lead_name):
+    """method to  Get data from the Lead in to child table in Mockup Design.
+    output: data from lead is mapped to a new mockup design document
+    """
+    lead = frappe.get_doc("Lead", lead_name)
+    if not lead:
+        frappe.throw(_("Lead not found"))
+
+    custom_property_table = []
+    for item in lead.custom_property_table:
+        custom_property_table.append({
+            'item_type': item.item_type,
+            'material_type': item.material_type,
+            'design': item.design,
+            'model': item.model,
+            'brand': item.brand,
+            'size_chart': item.size_chart,
+            'colour': item.colour,
+        })
+
+    return custom_property_table

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -1,8 +1,38 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Mockup Design", {
-// 	refresh(frm) {
 
-// 	},
-// });
+frappe.ui.form.on('Mockup Design', {
+    from_lead: function(frm) {
+      /*
+      * Function to populate  child table on selecting Lead.
+      */
+        if (frm.doc.from_lead) {
+            frappe.call({
+                method: 'versa_system.versa_system.custom_scripts.lead.lead.get_lead_properties',
+                args: {
+                    lead_name: frm.doc.from_lead
+                },
+                callback: function(r) {
+                    console.log('Response received:', r);
+                    if (r.message) {
+                        frm.clear_table("properties");
+
+                        r.message.forEach(function(item) {
+                            var row = frm.add_child("properties");
+                            row.item_type = item.item_type;
+                            row.material_type = item.material_type;
+                            row.design = item.design;
+                            row.model = item.model;
+                            row.brand = item.brand;
+                            row.size_chart = item.size_chart;
+                            row.colour = item.colour;
+                        });
+
+                        frm.refresh_field("properties");
+                    }
+                }
+            });
+        }
+    }
+});


### PR DESCRIPTION
## Feature description
Get data from the Lead in to child table in Mockup Design.

## Analysis and design (optional)
Get Data from the Lead in DocType "Mockup Design":
When we select a lead in Mockup Design,It should automatically fill the child table

## Solution description
 Mapped the Data  from  Lead in to child table in  Mockup Design.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/08a4a454-b08b-4471-9d25-e96d79328b7d)


## Areas affected and ensured
DocType-Mockup Design.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?

  - Mozilla Firefox
 
