### PR TITLE
feat:Quotation Button based on Mockup Design Approval

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -1,7 +1,6 @@
 
 frappe.ui.form.on('Lead', {
   refresh: function(frm) {
-
     setTimeout(() => {
       frm.remove_custom_button('Quotation', 'Create');
       frm.remove_custom_button('Customer', 'Create');
@@ -9,26 +8,52 @@ frappe.ui.form.on('Lead', {
       frm.remove_custom_button('Opportunity', 'Create');
     }, 10);
 
-    frm.add_custom_button(__('New Quotation'), function() {
+
+    let quotationButton=frm.add_custom_button(__('New Quotation'), function() {
       frappe.model.open_mapped_doc({
           method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_quotation',
           frm : frm
         });
     }, __('Create'));
 
-    frm.add_custom_button(__('Feasibility Property Check'), function() {
+
+
+     let feasibilityCheckButton=frm.add_custom_button(__('Feasibility Property Check'), function() {
       frappe.model.open_mapped_doc({
           method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_feasibility_check',
           frm : frm
         });
     }, __('Create'));
 
-    frm.add_custom_button(__('Mockup Design'), function() {
+      let mockupDesignButton=frm.add_custom_button(__('Mockup Design'), function() {
       frappe.model.open_mapped_doc({
           method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_mockup_design',
           frm : frm
         });
     }, __('Create'));
+
+
+    if (frm.doc.status === "Mockup Design Approved") {
+            mockupDesignButton.hide();
+            quotationButton.show();
+            feasibilityCheckButton.hide();
+        } else if(frm.doc.status === "Mockup Design Rejected"){
+            mockupDesignButton.hide();
+            quotationButton.hide();
+            feasibilityCheckButton.hide();
+        }else if (frm.doc.status === "Mockup Design Pending") {
+            mockupDesignButton.hide();
+            quotationButton.hide();
+            feasibilityCheckButton.hide();
+
+        }else {
+              // Default case: hide all buttons
+              quotationButton.hide();
+              mockupDesignButton.show();
+              feasibilityCheckButton.show();
+          }
+
+
 
     set_model_query(frm)
 

--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -8,52 +8,45 @@ frappe.ui.form.on('Lead', {
       frm.remove_custom_button('Opportunity', 'Create');
     }, 10);
 
-
-    let quotationButton=frm.add_custom_button(__('New Quotation'), function() {
+    let quotation_button=frm.add_custom_button(__('New Quotation'), function() {
       frappe.model.open_mapped_doc({
           method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_quotation',
           frm : frm
         });
     }, __('Create'));
 
-
-
-     let feasibilityCheckButton=frm.add_custom_button(__('Feasibility Property Check'), function() {
+     let feasibility_check_button=frm.add_custom_button(__('Feasibility Property Check'), function() {
       frappe.model.open_mapped_doc({
           method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_feasibility_check',
           frm : frm
         });
     }, __('Create'));
 
-      let mockupDesignButton=frm.add_custom_button(__('Mockup Design'), function() {
+      let mockup_design_button=frm.add_custom_button(__('Mockup Design'), function() {
       frappe.model.open_mapped_doc({
           method : 'versa_system.versa_system.custom_scripts.lead.lead.map_lead_to_mockup_design',
           frm : frm
         });
     }, __('Create'));
-
-
+     //Quotation button based on Mockup design status
     if (frm.doc.status === "Mockup Design Approved") {
-            mockupDesignButton.hide();
-            quotationButton.show();
-            feasibilityCheckButton.hide();
+            mockup_design_button.hide();
+            quotation_button.show();
+            feasibility_check_button.hide();
         } else if(frm.doc.status === "Mockup Design Rejected"){
-            mockupDesignButton.hide();
-            quotationButton.hide();
-            feasibilityCheckButton.hide();
+            mockup_design_button.hide();
+            quotation_button.hide();
+            feasibility_check_button.hide();
         }else if (frm.doc.status === "Mockup Design Pending") {
-            mockupDesignButton.hide();
-            quotationButton.hide();
-            feasibilityCheckButton.hide();
-
+            mockup_design_button.show();
+            quotation_button.hide();
+            feasibility_check_button.hide();
         }else {
               // Default case: hide all buttons
-              quotationButton.hide();
-              mockupDesignButton.show();
-              feasibilityCheckButton.show();
+              quotation_button.hide();
+              mockup_design_button.show();
+              feasibility_check_button.show();
           }
-
-
 
     set_model_query(frm)
 

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -2,8 +2,48 @@
 # For license information, please see license.txt
 
 # import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class MockupDesign(Document):
-	pass
+    def on_update(self):
+        if self.workflow_state == "Approved":
+            # Fetch the related lead document
+            lead = frappe.get_doc("Lead", self.from_lead)
+
+            # Update the lead status0
+            lead.status = "Mockup Design Approved"
+
+            # Save the changes to the lead document
+            lead.save()
+
+            # Optionally, you can add a comment to the lead document
+            lead.add_comment('Comment', 'Mockup Design approved and status updated.')
+
+        if self.workflow_state == "Rejected":
+            # Fetch the related lead document
+            lead = frappe.get_doc("Lead", self.from_lead)
+
+            # Update the lead status0
+            lead.status = "Mockup Design Rejected"
+
+            # Save the changes to the lead document
+            lead.save()
+
+            # Optionally, you can add a comment to the lead document
+            lead.add_comment('Comment', 'Mockup Design rejected and status updated.')
+
+
+        if self.workflow_state == "Pending":
+            # Fetch the related lead document
+            lead = frappe.get_doc("Lead", self.from_lead)
+
+            # Update the lead status0
+            lead.status = "Mockup Design Pending"
+
+            # Save the changes to the lead document
+            lead.save()
+
+            # Optionally, you can add a comment to the lead document
+            lead.add_comment('Comment', 'Mockup Design Pending and status updated.')


### PR DESCRIPTION
## Feature description
Need to add Quotation Button when the mockup Design is Approved .

## Solution description
Added Quotation Button Based on Mockup Design Approval.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/3ea6c354-d699-42ce-ae9d-60ae6c8dc013)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/ad07aedc-0abc-4553-8d72-932c84c1c17c)
.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
