### PR TITLE
fix: Image field should be mandatory

### DIFF
--- a/versa_system/versa_system/doctype/design/design.json
+++ b/versa_system/versa_system/doctype/design/design.json
@@ -22,7 +22,8 @@
   {
    "fieldname": "image",
    "fieldtype": "Attach Image",
-   "label": "Image"
+   "label": "Image",
+   "reqd": 1
   },
   {
    "fieldname": "model",
@@ -44,7 +45,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-06 14:08:14.598168",
+ "modified": "2024-06-11 12:08:44.583574",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design",

--- a/versa_system/versa_system/doctype/final_design/final_design.json
+++ b/versa_system/versa_system/doctype/final_design/final_design.json
@@ -21,7 +21,9 @@
   {
    "fieldname": "image",
    "fieldtype": "Attach",
-   "label": "Image"
+   "in_list_view": 1,
+   "label": "Image",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_edmg",
@@ -44,7 +46,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-07 10:26:23.097611",
+ "modified": "2024-06-11 12:09:05.973636",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Final Design",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -15,7 +15,8 @@
   {
    "fieldname": "image",
    "fieldtype": "Attach Image",
-   "label": "Mockup Design"
+   "label": "Mockup Design",
+   "reqd": 1
   },
   {
    "fieldname": "from_lead",
@@ -38,7 +39,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-07 10:25:22.285751",
+ "modified": "2024-06-11 12:05:41.639797",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",

--- a/versa_system/versa_system/doctype/model/model.json
+++ b/versa_system/versa_system/doctype/model/model.json
@@ -37,13 +37,14 @@
   {
    "fieldname": "image",
    "fieldtype": "Attach Image",
-   "label": "Image"
+   "label": "Image",
+   "reqd": 1
   }
  ],
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-07 15:42:07.028521",
+ "modified": "2024-06-11 12:08:26.714656",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Model",


### PR DESCRIPTION
## Issue description.
Documents can be save without attach file.

## Analysis and design (optional)
Image file should be mandatory 

## Solution description
Update this field using mandatory property .

## Areas affected and ensure
No.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
