### PR TITLE
fix:Add Naming Series in Final Design Doctype

### DIFF
--- a/versa_system/versa_system/doctype/final_design/final_design.json
+++ b/versa_system/versa_system/doctype/final_design/final_design.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:{FD}-{####}",
  "creation": "2024-06-05 16:13:21.497345",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -44,10 +45,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-07 10:26:23.097611",
+ "modified": "2024-06-11 12:19:16.532193",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Final Design",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
## Issue description
There is no Naming Series added in Final Design.

## Analysis and design (optional)
Naming Series Should be Added in Final Design.

## Solution description
Added Naming Series by expression in Final Design.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/e3867787-416b-4acc-9ae3-5b1f6f63e120)


## Areas affected and ensured
Naming Series added in Final Design Doctype.

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
