### PR TITLE
feat:Created Child DocType Named Size Attribute

### DIFF
--- a/versa_system/versa_system/doctype/size_attribute/size_attribute.json
+++ b/versa_system/versa_system/doctype/size_attribute/size_attribute.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-06-12 10:10:45.734383",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "attribute",
+  "value",
+  "uom"
+ ],
+ "fields": [
+  {
+   "fieldname": "attribute",
+   "fieldtype": "Data",
+   "label": "Attribute"
+  },
+  {
+   "fieldname": "value",
+   "fieldtype": "Float",
+   "label": "Value"
+  },
+  {
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-06-12 10:17:33.377551",
+ "modified_by": "Administrator",
+ "module": "Versa System",
+ "name": "Size Attribute",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/versa_system/versa_system/doctype/size_attribute/size_attribute.py
+++ b/versa_system/versa_system/doctype/size_attribute/size_attribute.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SizeAttribute(Document):
+	pass


### PR DESCRIPTION
## Feature description
Need to Create Child DocType Named Size Attribute.

## Solution description
Created Child DocType Named Size Attribute.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/225f3399-7d9d-4b8f-8215-97019a2c5d86)
.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
