### PR TITLE
fix:Changed the Naming Series for the DocType Raw Material Bundel

### DIFF
--- a/versa_system/versa_system/doctype/raw_material/raw_material.json
+++ b/versa_system/versa_system/doctype/raw_material/raw_material.json
@@ -21,6 +21,7 @@
   {
    "fieldname": "quantity",
    "fieldtype": "Float",
+   "in_list_view": 1,
    "label": "Quantity"
   },
   {
@@ -34,7 +35,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-12 10:32:57.708179",
+ "modified": "2024-06-12 11:10:19.953805",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material",

--- a/versa_system/versa_system/doctype/raw_material_bundle/raw_material_bundle.json
+++ b/versa_system/versa_system/doctype/raw_material_bundle/raw_material_bundle.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:RMB-{DD}{MM}{YY}-{####}",
  "creation": "2024-06-12 11:11:23.271381",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -17,10 +18,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-12 11:12:26.523575",
+ "modified": "2024-06-12 12:29:45.467014",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material Bundle",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
## Feature description
Absence of Naming Series or the DocType Raw Material Bundle

## Solution description
Added the Naming Series for the DocType Raw Material Bundle

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/c3d713fb-ce8f-4902-acf0-c6a01d882cbd)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 
