### PR TITLE
feat : Updating Size chart

### DIFF
--- a/versa_system/versa_system/doctype/size_attribute/size_attribute.json
+++ b/versa_system/versa_system/doctype/size_attribute/size_attribute.json
@@ -14,11 +14,13 @@
   {
    "fieldname": "attribute",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Attribute"
   },
   {
    "fieldname": "value",
    "fieldtype": "Float",
+   "in_list_view": 1,
    "label": "Value"
   },
   {
@@ -32,7 +34,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-12 10:17:33.377551",
+ "modified": "2024-06-12 10:49:29.265088",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Size Attribute",

--- a/versa_system/versa_system/doctype/size_chart/size_chart.json
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.json
@@ -6,47 +6,33 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "uom",
-  "length",
-  "width",
-  "radius",
-  "dimension"
+  "reference_doctype",
+  "reference_name",
+  "size_attributes"
  ],
  "fields": [
   {
-   "fieldname": "length",
-   "fieldtype": "Float",
-   "label": "Length",
-   "precision": "2"
-  },
-  {
-   "fieldname": "width",
-   "fieldtype": "Float",
-   "label": "Width",
-   "precision": "2"
-  },
-  {
-   "fieldname": "radius",
-   "fieldtype": "Float",
-   "label": "Radius",
-   "precision": "2"
-  },
-  {
-   "fieldname": "dimension",
-   "fieldtype": "Float",
-   "label": "Dimension",
-   "precision": "2"
-  },
-  {
-   "fieldname": "uom",
+   "fieldname": "reference_doctype",
    "fieldtype": "Link",
-   "label": "Unit of Measure",
-   "options": "UOM"
+   "label": "Reference Doctype",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Name",
+   "options": "reference_doctype"
+  },
+  {
+   "fieldname": "size_attributes",
+   "fieldtype": "Table",
+   "label": "Size Attributes",
+   "options": "Size Attribute"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-05 12:50:07.825650",
+ "modified": "2024-06-12 11:03:10.228720",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Size Chart",


### PR DESCRIPTION
## Feature description
Need to recreate size chart doctype.

## Analysis and design (optional)
Updating fields

## Solution description
Created Doctype size chart

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/f340dd14-a4cd-4c7d-afb0-9e853f555599)


## Areas affected and ensured
Size Chart Doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
