### PR TITLE
fix : Need to Filter Doctypes Of Versa System

### DIFF
--- a/versa_system/versa_system/doctype/size_chart/size_chart.js
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.js
@@ -1,12 +1,5 @@
-
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
-
-// frappe.ui.form.on("Size Chart", {
-// 	refresh(frm) {
-
-// 	},
-// });
 
 frappe.ui.form.on('Size Chart', {
     onload: function(frm) {

--- a/versa_system/versa_system/doctype/size_chart/size_chart.js
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.js
@@ -1,4 +1,12 @@
 
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Size Chart", {
+// 	refresh(frm) {
+
+// 	},
+// });
 
 frappe.ui.form.on('Size Chart', {
     onload: function(frm) {

--- a/versa_system/versa_system/doctype/size_chart/size_chart.js
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.js
@@ -1,8 +1,14 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
 
-// frappe.ui.form.on("Size Chart", {
-// 	refresh(frm) {
 
-// 	},
-// });
+frappe.ui.form.on('Size Chart', {
+    onload: function(frm) {
+        frm.set_query('reference_doctype', function() {
+            return {
+              "filters":{
+                module: 'Versa System'
+              }
+
+            };
+        });
+    }
+});


### PR DESCRIPTION
## Feature description
Need to Add Filter 

## Analysis and design (optional)
Adding filter

## Solution description
Added filter to display only doctypes of module versa system

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/09b07183-924a-463e-a464-a03a798253af)


## Areas affected and ensured
Doctype Size Chart

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox-yes
  - Opera Mini
  - Safari
