### PR TITLE
Feat:Create a button in Properties Child Table in lead,which directs to Size Chart DocType

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -67,6 +67,18 @@ frappe.ui.form.on('Lead', {
     }, 10);
   }
 });
+frappe.ui.form.on('Properties Table', {
+    create_size_chart: function(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+
+        // Create a new document for the 'Size Chart' doctype
+        frappe.new_doc('Size Chart', {
+            'property': row.name,
+            'lead': frm.doc.name
+        });
+    }
+});
+
 
 frappe.ui.form.on("Properties Table", {
   item_type: function(frm, cdt, cdn) {


### PR DESCRIPTION

## Feature description
 Need for a Button in Properties Child Table in lead 

## Solution description
Created a button in Properties Child Table in lead,which directs to Size Chart DocType

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/f150b8d2-14d3-49eb-9abd-5a6bcb657c82)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/8a735803-af35-45cd-9f66-d28aa2dfec4a)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  