### PR TITLE
Feat:Create a button in Properties Child Table

### DIFF
--- a/versa_system/versa_system/doctype/properties_table/properties_table.json
+++ b/versa_system/versa_system/doctype/properties_table/properties_table.json
@@ -15,7 +15,8 @@
   "colour",
   "customized",
   "low_range",
-  "high_range"
+  "high_range",
+  "create_size_chart"
  ],
  "fields": [
   {
@@ -81,12 +82,17 @@
    "fieldname": "quantity",
    "fieldtype": "Int",
    "label": "Quantity"
+  },
+  {
+   "fieldname": "create_size_chart",
+   "fieldtype": "Button",
+   "label": "Create Size Chart"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-12 10:23:19.003350",
+ "modified": "2024-06-12 15:40:55.298510",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Properties Table",


### PR DESCRIPTION
## Feature description
 Need for a Button in Properties Child Table in lead 

## Solution description
Created a button in Properties Child Table in lead,which directs to Size Chart DocType

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/f150b8d2-14d3-49eb-9abd-5a6bcb657c82)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/8a735803-af35-45cd-9f66-d28aa2dfec4a)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  