### PR TITLE
feat:Add Reference Name and Reference Doctype fields for the DocType Raw Material Bundle

### DIFF
--- a/versa_system/versa_system/doctype/raw_material_bundle/raw_material_bundle.json
+++ b/versa_system/versa_system/doctype/raw_material_bundle/raw_material_bundle.json
@@ -6,6 +6,8 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "reference_doctype",
+  "reference_name",
   "raw_material"
  ],
  "fields": [
@@ -14,11 +16,23 @@
    "fieldtype": "Table",
    "label": "Raw Material",
    "options": "Raw Material"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference Doctype",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Name",
+   "options": "reference_doctype"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-12 12:29:45.467014",
+ "modified": "2024-06-13 09:17:46.715139",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material Bundle",


### PR DESCRIPTION

## Feature description
Needed to Add Reference Name and Reference DocType fields for the DocType Raw Material Bundle

## Solution description
Added Reference Name and Reference Doctype fields

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/1a505bff-61b4-4dac-80d5-39a271ce9a25)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
 