### PR TITLE
fix:Apply filters on Reference DocType Field in Raw Material Bundle DocType& Automatic Fetching of UOM for uom field in Raw Material Doctype

### DIFF
--- a/versa_system/versa_system/doctype/raw_material/raw_material.json
+++ b/versa_system/versa_system/doctype/raw_material/raw_material.json
@@ -25,6 +25,7 @@
    "label": "Quantity"
   },
   {
+   "fetch_from": "item_code.stock_uom",
    "fieldname": "uom",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -35,7 +36,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-12 11:10:19.953805",
+ "modified": "2024-06-13 11:30:40.849393",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material",

--- a/versa_system/versa_system/doctype/raw_material_bundle/raw_material_bundle.js
+++ b/versa_system/versa_system/doctype/raw_material_bundle/raw_material_bundle.js
@@ -1,8 +1,15 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Raw Material Bundle", {
-// 	refresh(frm) {
+frappe.ui.form.on('Raw Material Bundle', {
+    onload: function(frm) {
+        frm.set_query('reference_doctype', function() {
+            return {
+              "filters":{
+                module: 'Versa System'
+              }
 
-// 	},
-// });
+            };
+        });
+    }
+});


### PR DESCRIPTION

## Feature description
Absence of filters on Reference DocType Field in Raw Material Bundle DocType & Automatic Fetching of UOM for uom field in Raw Material DocType

## Solution description
Applied Filters and Automatic fetching of UOM are done.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/1513f667-2f80-4ae9-bde2-47543410a36a)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/b0d6b3d8-b6ba-4515-aad0-ce7dfd2a1e57)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/20acdb23-7c9f-4176-8831-c0aadee552de)
![image](https://github.com/efeoneAcademy/versa_system/assets/78547193/484d88eb-276e-4137-a980-e507797e5523)

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
