### PR TITLE
feat:Get Datas From Lead to Quotation

### DIFF
--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe.model.mapper import get_mapped_doc
 from frappe import _
-
 @frappe.whitelist()
 def map_lead_to_quotation(source_name, target_doc=None):
     '''
@@ -16,7 +15,15 @@ def map_lead_to_quotation(source_name, target_doc=None):
             "Lead": {
                 "doctype": "Quotation",
                 "field_map": {
-                    "name": "party_name"
+                    "lead_name": "party_name",
+                },
+            },
+
+            "Properties Table":{
+                "doctype": "Quotation Item",
+                "field_map": {
+                    'quantity':'qty',
+                    'item_code':'item_code'
                 },
             },
         }, target_doc, set_missing_values)

--- a/versa_system/versa_system/doctype/item_type/item_type.json
+++ b/versa_system/versa_system/doctype/item_type/item_type.json
@@ -6,6 +6,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "item",
   "item_type"
  ],
  "fields": [
@@ -14,11 +15,17 @@
    "fieldtype": "Data",
    "label": "Item Type",
    "unique": 1
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "label": "Item",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-05-31 11:53:42.668380",
+ "modified": "2024-06-12 16:43:15.129122",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Item Type",

--- a/versa_system/versa_system/doctype/properties_table/properties_table.json
+++ b/versa_system/versa_system/doctype/properties_table/properties_table.json
@@ -6,6 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "item_code",
   "item_type",
   "quantity",
   "brand",
@@ -87,12 +88,19 @@
    "fieldname": "create_size_chart",
    "fieldtype": "Button",
    "label": "Create Size Chart"
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-12 15:40:55.298510",
+ "modified": "2024-06-14 09:49:17.822727",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Properties Table",


### PR DESCRIPTION
## Feature description
Need to get Datas from Lead to Quotation Automatically.

## Analysis and design (optional)
Get datas from Lead to Quotation
   -fetch data (Item,Quantity) from Lead to Quotation

## Solution description
Datas From Lead to Quotation are Automatically Updated.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/ba28c506-d4f9-4db3-a304-67c314b92961)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
   - Mozilla Firefox
 
