### PR TITLE
fix:One field is set to Read-Only in the raw material doctype

### DIFF
--- a/versa_system/versa_system/doctype/raw_material/raw_material.json
+++ b/versa_system/versa_system/doctype/raw_material/raw_material.json
@@ -31,12 +31,39 @@
    "in_list_view": 1,
    "label": "UOM",
    "options": "UOM"
+<<<<<<< Updated upstream
+=======
+  },
+  {
+   "fieldname": "rate",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Rate"
+  },
+  {
+   "fieldname": "total_amount",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Total Amount",
+   "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "quantity",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Quantity"
+>>>>>>> Stashed changes
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
+<<<<<<< Updated upstream
  "modified": "2024-06-13 11:30:40.849393",
+=======
+ "modified": "2024-06-14 10:00:26.498671",
+>>>>>>> Stashed changes
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material",


### PR DESCRIPTION
## Issue description
A field is need to be set as "read-only" in the raw material doctype.

## Solution description
field is changed to "read-only"in the raw material doctype(Total Amount Field)

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117796265/8a1e52d4-876e-4e76-80b7-1c89b7ffb380)
![image](https://github.com/efeoneAcademy/versa_system/assets/117796265/7237e429-9b38-41a0-a089-ffba4db9cccd)


## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
