### PR TITLE
feat:Create View Size Chart Button in Feasibility Solution Doctype

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -73,8 +73,20 @@ frappe.ui.form.on('Lead', {
 frappe.ui.form.on("Properties Table", {
   item_type: function(frm, cdt, cdn) {
     set_model_query(frm);
+  },
+  create_size_chart: function(frm, cdt, cdn) {
+      let row = locals[cdt][cdn];
+
+      frappe.new_doc('Size Chart', {
+
+      });
+      frappe.route_options = {
+          "reference_doctype": "Properties Table",
+          "reference_name": row.name
+      };
   }
 });
+
 
 function set_model_query(frm) {
   /*
@@ -89,20 +101,3 @@ function set_model_query(frm) {
     };
   }
 }
-
-
-frappe.ui.form.on('Properties Table', {
-    create_size_chart: function(frm, cdt, cdn) {
-        let row = locals[cdt][cdn];
-
-        frappe.new_doc('Size Chart', {
-            'property': row.name,
-            'lead': frm.doc.name
-        });
-        frappe.route_options = {
-            "reference_doctype": "Properties Table",
-            "reference_name": row.name
-        };
-        frappe.new_doc('Size Chart');
-    }
-});

--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -170,3 +170,22 @@ def map_lead_to_final_design(source_name, target_doc=None):
         }, target_doc, set_missing_values)
 
     return target_doc
+
+
+@frappe.whitelist()
+def fetch_size_chart_details(reference=None):
+    '''
+        Method: Fetches size attributes from a Size Chart based on a provided reference.
+
+        Output: Returns a list containing size attribute details 
+    '''
+    if reference:
+        size_chart_name = frappe.db.get_value("Size Chart", {"reference_name": reference}, "name")
+        if size_chart_name:
+            size_attributes = frappe.get_all("Size Attribute",filters={"parenttype": "Size Chart","parent": size_chart_name},fields=["attribute", "value", "uom"])
+            return size_attributes
+        else:
+            frappe.msgprint("Size Chart not found for the given reference.")
+            return []
+    else:
+        frappe.throw("Reference is required.")

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -37,6 +37,37 @@ frappe.ui.form.on('Feasibility Solution', {
             'reference_doctype': 'Feasibility Solution',
             'reference_name': row.name,
         })
+    },
+    /*
+    Function to view size chart attributes
+     */
+    view_size_chart: function(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        console.log(row);
+        frappe.call({
+            method: 'versa_system.versa_system.custom_scripts.lead.lead.fetch_size_chart_details',
+            args: {
+                'reference': row.reference
+            },
+            callback: function(response) {
+                if (response.message && response.message.length > 0) {
+                    let size_html = '<table class="table table-bordered">';
+                    size_html += '<tr><th>Attribute</th><th>Value</th><th>UOM</th></tr>';
+                    response.message.forEach(attr => {
+                        size_html += `<tr><td>${attr.attribute}</td><td>${attr.value}</td><td>${attr.uom}</td></tr>`;
+                    });
+
+                    size_html += '</table>';
+
+                    frappe.msgprint({
+                        title: 'Size Attributes',
+                        message: size_html
+                    });
+                } else {
+                    frappe.msgprint(__('No size attributes available for this Feasibility Solution.'));
+                }
+            }
+        });
     }
 });
 

--- a/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.json
+++ b/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.json
@@ -13,7 +13,7 @@
   "model",
   "colour",
   "brand_name",
-  "size_chart",
+  "view_size_chart",
   "go_forward",
   "remark",
   "create_raw_material",
@@ -63,13 +63,6 @@
    "options": "Brand"
   },
   {
-   "fieldname": "size_chart",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Size Chart",
-   "options": "Size Chart"
-  },
-  {
    "default": "0",
    "fieldname": "go_forward",
    "fieldtype": "Check",
@@ -92,6 +85,11 @@
    "fieldname": "reference",
    "fieldtype": "Data",
    "label": "Reference"
+  },
+  {
+   "fieldname": "view_size_chart",
+   "fieldtype": "Button",
+   "label": "View Size Chart"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.py
+++ b/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 

--- a/versa_system/versa_system/doctype/size_chart/size_chart.json
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.json
@@ -32,7 +32,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-13 15:58:26.163426",
+ "modified": "2024-06-18 17:16:44.756356",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Size Chart",


### PR DESCRIPTION
## Feature description
Need to Create View Size Chart Button in Feasibility Solution.

## Analysis and design
Create a Button in Feasibility Check to show "Size chart":
Create a button in properties table named "show size chart"
when we click this button show size chart details

## Solution description
Created the View Size Chart Button in Feasibility Solution and fetched size chart details in a dialog box.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/dcb1eb65-f656-4836-b856-08aeca6986a9)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/de2a40be-4ec0-4bc4-94e2-79d3797cf743)


## Areas affected and ensured
New Feature.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
 - Mozilla Firefox
 
