### PR TITLE
feat:Create new button in properties table

### DIFF
--- a/versa_system/versa_system/doctype/properties_table/properties_table.json
+++ b/versa_system/versa_system/doctype/properties_table/properties_table.json
@@ -18,7 +18,8 @@
   "customized",
   "low_range",
   "high_range",
-  "create_size_chart"
+  "create_size_chart",
+  "show_features"
  ],
  "fields": [
   {
@@ -96,12 +97,17 @@
    "in_list_view": 1,
    "label": "Item Code",
    "options": "Item"
+  },
+  {
+   "fieldname": "show_features",
+   "fieldtype": "Button",
+   "label": "Show Features"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-18 11:05:47.353351",
+ "modified": "2024-06-19 09:57:07.406391",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Properties Table",


### PR DESCRIPTION
## Feature description
Need a button in properties table "Show Feature".

## Analysis and design (optional)
Create new button "Show Features " in Properties Table

## Solution description
Create new button "Show Features " in Properties Table.

##Output screenshot
![image](https://github.com/efeoneAcademy/versa_system/assets/117906220/01621a68-13b2-4e60-b3c8-5349ef4713a9)

## Areas affected and ensured
Properties Table.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
