### PR TITLE
fix: Automatically fetch reference_doctype and reference_name in Size…

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -78,23 +78,18 @@ frappe.ui.form.on("Properties Table", {
       let row = locals[cdt][cdn];
 
       frappe.new_doc('Size Chart', {
-
+        "reference_doctype": "Properties Table",
+        "reference_name": row.name
       });
-      frappe.route_options = {
-          "reference_doctype": "Properties Table",
-          "reference_name": row.name
-      };
+
   },
   create_features: function(frm, cdt , cdn) {
        let row = locals[cdt][cdn];
 
        frappe.new_doc('Feature',{
-
+         "reference_doctype": "Properties Table",
+         "reference_name": row.name
        });
-       frappe.route_options = {
-           "reference_doctype": "Properties Table",
-           "reference_name": row.name
-       };
      }
 });
 

--- a/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.json
+++ b/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.json
@@ -81,6 +81,11 @@
    "fieldname": "show_features",
    "fieldtype": "Button",
    "label": "Show Features"
+  },
+  {
+   "fieldname": "view_size_chart",
+   "fieldtype": "Button",
+   "label": "View Size Chart"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/versa_system/versa_system/doctype/size_chart/size_chart.json
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.json
@@ -1,3 +1,4 @@
+
 {
  "actions": [],
  "allow_rename": 1,


### PR DESCRIPTION
… Chart and Features Doctype.

## Feature description
Need to automatically fetch reference doctype and reference name in Size Chart and Features Doctype.

## Solution description
Automatically fetched reference doctype and reference name in Size Chart and Features Doctype.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/134713de-baa7-42a8-8456-c4bd02bd12d6)
![image](https://github.com/efeoneAcademy/versa_system/assets/118014735/ff46b214-e041-4f6c-9862-763619d05f63)

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?
- Mozilla Firefox

