### PR TITLE
feat:A popup  message to show the features in the mockup design doctype

### DIFF
--- a/versa_system/versa_system/doctype/final_design/final_design.js
+++ b/versa_system/versa_system/doctype/final_design/final_design.js
@@ -84,6 +84,10 @@ frappe.ui.form.on('Final Design', {
 
 frappe.ui.form.on('Properties Table', {
   show_features: function(frm, cdt, cdn) {
+       /**
+       * Function to display features for a selected property.
+       * Fetches and displays feature details in a message box.
+       */
       let row = locals[cdt][cdn];
       console.log(row);
       frappe.call({

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -33,3 +33,41 @@ frappe.ui.form.on('Mockup Design', {
         }
     }
 });
+frappe.ui.form.on('Properties Table', {
+  create_raw_material: function(frm, cdt , cdn) {
+    let row = locals[cdt][cdn];
+    frappe.new_doc('Raw Material Bundle', {
+      'reference_doctype': 'Properties Table',
+      'reference_name': row.name,
+    })
+  },
+
+  show_features: function(frm, cdt, cdn) {
+       /**
+       * Function to display features for a selected property.
+       * Fetches and displays feature details in a message box.
+       */
+      let row = locals[cdt][cdn];
+      frappe.call({
+          method: 'versa_system.versa_system.custom_scripts.lead.lead.fetch_feature_detail',
+          callback: function(response) {
+              if (response.message && response.message.length > 0) {
+                  let feature_html = '<table class="table table-bordered">';
+                  feature_html += '<tr><th>Attribute</th><th>Value</th></tr>';
+                  response.message.forEach(attr => {
+                      feature_html += `<tr><td>${attr.attribute}</td><td>${attr.value}</td></tr>`;
+                  });
+
+                  feature_html += '</table>';
+
+                  frappe.msgprint({
+                      title: 'Features',
+                      message: feature_html
+                  });
+              } else {
+                  frappe.msgprint(__('No Features available for this Properties Table.'));
+              }
+          }
+    });
+}
+});


### PR DESCRIPTION
## Feature description
A pop up message to show the features in the mockup design doctype

## Solution description
Created a popup box which shows the 'Features' in the Mockup Design.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117796265/d0d39446-7301-4451-bf2d-aba5f0a203ca)
![image](https://github.com/efeoneAcademy/versa_system/assets/117796265/b8f81648-956c-4409-ba72-dcd563dbeff4)

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Mozilla Firefox
  