### PR TITLE
feat:create button Show Raw Material

### DIFF
--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -172,7 +172,7 @@ def fetch_size_chart_details(reference=None):
         Output: Returns a list containing size attribute details
     '''
     if reference:
-        size_chart_name = frappe.db.get_value("Size Chart", {"reference_name": reference}, "name")
+        size_chart_name = frappe.db.exists("Size Chart", {"reference_name": reference})
         if size_chart_name:
             size_attributes = frappe.get_all("Size Attribute",filters={"parenttype": "Size Chart","parent": size_chart_name},fields=["attribute", "value", "uom"])
             return size_attributes
@@ -181,6 +181,7 @@ def fetch_size_chart_details(reference=None):
             return []
     else:
         frappe.throw("Reference is required.")
+
 
 
 @frappe.whitelist()
@@ -197,6 +198,22 @@ def fetch_feature_details(reference=None):
             return feature_details
         else:
             frappe.msgprint("Feature not found for the given reference.")
+
+
+@frappe.whitelist()
+def fetch_raw_material_details(reference=None):
+    '''
+        Method: Fetches Raw Material from a Raw Material Bundle based on a provided reference.
+
+        Output: Returns a list containing raw material details
+    '''
+    if reference:
+        raw_material_name = frappe.db.exists("Raw Material Bundle", {"reference_name": reference})
+        if raw_material_name:
+            raw_material = frappe.get_all("Raw Material",filters={"parenttype": "Raw Material Bundle","parent": raw_material_name},fields=["item_code", "quantity", "uom","rate","total_amount"])
+            return raw_material
+        else:
+            frappe.msgprint("Raw Material not found for the given reference.")
             return []
     else:
         frappe.throw("Reference is required.")

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -66,6 +66,7 @@ frappe.ui.form.on('Feasibility Solution', {
             }
         });
     },
+
     show_features: function(frm, cdt, cdn) {
         let row = locals[cdt][cdn];
         console.log(row);
@@ -90,6 +91,34 @@ frappe.ui.form.on('Feasibility Solution', {
                     });
                 } else {
                     frappe.msgprint(__('No Features available for this Feasibility Solution.'));
+                }
+            }
+
+        });
+    },
+
+    show_raw_material: function(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        frappe.call({
+            method: 'versa_system.versa_system.custom_scripts.lead.lead.fetch_raw_material_details',
+            args: {
+                'reference': cdn
+            },
+            callback: function(response) {
+                if (response.message && response.message.length > 0) {
+                    let raw_html = '<table class="table table-bordered">';
+                    raw_html += '<tr><th>Item Code</th><th>Quantity</th><th>UOM</th><th>Rate</th><th>Total Amount</th></tr>';
+                    response.message.forEach(attr => {
+                        raw_html += `<tr><td>${attr.item_code}</td><td>${attr.quantity}</td><td>${attr.uom}</td><td>${attr.rate}</td><td>${attr.total_amount}</td></tr>`;
+                    });
+                    raw_html += '</table>';
+
+                    frappe.msgprint({
+                        title: 'Raw Material',
+                        message: raw_html
+                    });
+                } else {
+                    frappe.msgprint(__('No Raw Material available for this Feasibility Solution.'));
                 }
             }
         });

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -6,6 +6,13 @@ from frappe.model.document import Document
 
 
 class FeasibilityCheck(Document):
+	def onload(self):
+		for row in self.properties:
+			if frappe.db.exists("Raw Material Bundle", {"reference_doctype":row.doctype,"reference_name":row.name}):
+				row.raw_material_exists = 1
+			else:
+				row.raw_material_exists = 0
+
 	def on_update(self):
 	    if self.workflow_state == "Approved":
 	        # Fetch the related lead document

--- a/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.json
+++ b/versa_system/versa_system/doctype/feasibility_solution/feasibility_solution.json
@@ -15,9 +15,11 @@
   "view_size_chart",
   "go_forward",
   "remark",
-  "create_raw_material",
   "reference",
-  "show_features"
+  "show_features",
+  "create_raw_material",
+  "show_raw_material",
+  "raw_material_exists"
  ],
  "fields": [
   {
@@ -26,6 +28,11 @@
    "in_list_view": 1,
    "label": "Item Type",
    "options": "Item Type"
+  },
+  {
+   "fieldname": "view_size_chart",
+   "fieldtype": "Button",
+   "label": "View Size Chart"
   },
   {
    "default": "0",
@@ -42,6 +49,7 @@
    "label": "Remark"
   },
   {
+   "depends_on": "eval: !doc.raw_material_exists",
    "fieldname": "create_raw_material",
    "fieldtype": "Button",
    "label": "Create Raw Material"
@@ -52,15 +60,10 @@
    "label": "Reference"
   },
   {
-   "fieldname": "view_size_chart",
+   "depends_on": "eval: doc.raw_material_exists",
+   "fieldname": "show_raw_material",
    "fieldtype": "Button",
-   "label": "View Size Chart"
-  },
-  {
-   "fieldname": "item_code",
-   "fieldtype": "Link",
-   "label": "Item Code",
-   "options": "Item"
+   "label": "Show Raw Material"
   },
   {
    "fieldname": "quantity",
@@ -83,15 +86,24 @@
    "label": "Show Features"
   },
   {
-   "fieldname": "view_size_chart",
-   "fieldtype": "Button",
-   "label": "View Size Chart"
+   "default": "0",
+   "fieldname": "raw_material_exists",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Raw Material Exists"
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-19 15:08:53.676585",
+ "modified": "2024-06-20 16:29:54.308572",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Solution",

--- a/versa_system/versa_system/doctype/raw_material/raw_material.json
+++ b/versa_system/versa_system/doctype/raw_material/raw_material.json
@@ -58,7 +58,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-14 11:59:59.689016",
+ "modified": "2024-06-20 15:18:00.330595",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material",


### PR DESCRIPTION
## Feature description
Need to create button  "Show Raw Material" and while clicking on it,needs to show the raw material details as a pop-up message and when created once hide the button "Create Raw Material.

## Solution description
Created button "Show Raw Material" and while clicking on it showed the raw material details as a pop-up message and hide the button "Create Raw Material" when created once.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/4dffadf3-dfeb-4cac-aae8-c828839ec61d)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/acb2500c-c179-4471-b1b2-4cdf0b8fbc56)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/cb8a3b7d-de16-4b5f-bc82-f1ead253b24e)


## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
