### PR TITLE
fix: Ensure at least one 'Go Forward' checkbox is required before saving Feasibility Check

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -7,8 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "from_lead",
-  "properties",
-  "go_forward"
+  "go_forward",
+  "properties"
  ],
  "fields": [
   {
@@ -30,13 +30,12 @@
    "default": "0",
    "fieldname": "go_forward",
    "fieldtype": "Check",
-   "label": "Go Forward",
-   "read_only": 1
+   "label": "Go Forward"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-20 17:15:19.475424",
+ "modified": "2024-06-24 15:31:54.938887",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Check",


### PR DESCRIPTION
## Feature description
Need to ensure that at least one "Go Forward" checkbox is selected in the child table before the form can be saved.

## Solution description
Added a validation rule to ensure that at least one "Go Forward" checkbox in the child table is selected before the form can be saved.

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/125202476/bff85c54-7a1f-445e-9d84-ff839ccaad27)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox

