### PR TITLE
fix:Added Filters in Final Design and Mockup Design doctype

### DIFF
--- a/versa_system/versa_system/doctype/attribute/attribute.json
+++ b/versa_system/versa_system/doctype/attribute/attribute.json
@@ -12,13 +12,15 @@
   {
    "fieldname": "attribute",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Attribute",
+   "reqd": 1,
    "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-24 10:25:36.840850",
+ "modified": "2024-06-24 15:11:15.225563",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Attribute",

--- a/versa_system/versa_system/doctype/final_design/final_design.js
+++ b/versa_system/versa_system/doctype/final_design/final_design.js
@@ -113,3 +113,15 @@ frappe.ui.form.on('Properties Table', {
       });
   }
 });
+frappe.ui.form.on('Final Design', {
+    onload: function(frm) {
+        frm.set_query('from_lead', function() {
+            return {
+              "filters":{
+                Status :'Quotation'
+              }
+
+            };
+        });
+    }
+});

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -71,3 +71,15 @@ frappe.ui.form.on('Properties Table', {
     });
 }
 });
+frappe.ui.form.on('Mockup Design', {
+    onload: function(frm) {
+        frm.set_query('from_lead', function() {
+            return {
+              "filters":{
+                Status :'Feasibility check Approved'
+              }
+
+            };
+        });
+    }
+});


### PR DESCRIPTION
## Issue  description
 Need to Apply  the Filters in Final Design and Mockup Design doctype

## Analysis and design (optional)
Filters should be apply  in the Final Design and Mockup Design doctype

## Solution description
Applied he Filters in Final Design and Mockup Design doctype


## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/085961c1-4143-48e2-a59b-372ab6ad6750)
![image](https://github.com/efeoneAcademy/versa_system/assets/170389963/b3deffbd-a8a9-44fb-b7e8-f6210a4c34c3)


## Areas affected and ensured
  Filters applied Final Design and Mockup design Doctype.

## Is there any existing behavior change of other features due to this code change?
Final Design and the Mockup Design Doctype

## Was this feature tested on the browsers?
  
  - Mozilla Firefox
  
