### PR TITLE
fix : Hidding Fields of Child Table

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -107,3 +107,15 @@ function set_model_query(frm) {
     };
   }
 }
+
+frappe.ui.form.on('Lead', {
+    refresh: function(frm) {
+        if (frm.doc.custom_property_table) {
+
+            // Update docfield properties to hide the fields
+            frm.fields_dict.custom_property_table.grid.update_docfield_property('mockup_design', 'hidden', 1);
+            frm.fields_dict.custom_property_table.grid.update_docfield_property('final_design', 'hidden', 1);
+            frm.fields_dict.custom_property_table.grid.update_docfield_property('show_features', 'hidden', 1);
+        }
+    }
+});

--- a/versa_system/versa_system/doctype/final_design/final_design.js
+++ b/versa_system/versa_system/doctype/final_design/final_design.js
@@ -125,3 +125,14 @@ frappe.ui.form.on('Final Design', {
         });
     }
 });
+
+frappe.ui.form.on('Final Design', {
+    refresh: function(frm) {
+        if (frm.doc.properties) {
+
+            // Update docfield properties to hide the fields
+            frm.fields_dict.properties.grid.update_docfield_property('create_size_chart', 'hidden', 1);
+            frm.fields_dict.properties.grid.update_docfield_property('create_features', 'hidden', 1);
+        }
+    }
+});

--- a/versa_system/versa_system/doctype/final_design/final_design.json
+++ b/versa_system/versa_system/doctype/final_design/final_design.json
@@ -8,7 +8,6 @@
  "field_order": [
   "from_lead",
   "column_break_edmg",
-  "image",
   "section_break_hcmb",
   "properties_table",
   "section_break_ipql",
@@ -18,15 +17,9 @@
   {
    "fieldname": "from_lead",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "From Lead",
    "options": "Lead",
-   "reqd": 1
-  },
-  {
-   "fieldname": "image",
-   "fieldtype": "Attach",
-   "in_list_view": 1,
-   "label": "Image",
    "reqd": 1
   },
   {
@@ -52,13 +45,12 @@
    "fieldname": "properties_table",
    "fieldtype": "Table",
    "label": "Properties ",
-   "options": "Properties Table",
-   "read_only": 1
+   "options": "Properties Table"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-24 10:37:58.895938",
+ "modified": "2024-06-25 12:29:59.134512",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Final Design",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -1,12 +1,11 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-
 frappe.ui.form.on('Mockup Design', {
     from_lead: function(frm) {
-      /*
-      * Function to populate  child table on selecting Lead.
-      */
+        /*
+        * Function to populate child table on selecting Lead.
+        */
         if (frm.doc.from_lead) {
             frappe.call({
                 method: 'versa_system.versa_system.custom_scripts.lead.lead.get_lead_properties',
@@ -19,10 +18,10 @@ frappe.ui.form.on('Mockup Design', {
 
                         r.message.forEach(function(item) {
                             var row = frm.add_child("properties");
-                            row.item_type  = item.item_type;
-                            row.item_code  = item.item_code;
-                            row.quantity   = item.quantity;
-                            row.low_range  = item.low_range;
+                            row.item_type = item.item_type;
+                            row.item_code = item.item_code;
+                            row.quantity = item.quantity;
+                            row.low_range = item.low_range;
                             row.high_range = item.high_range;
                         });
 
@@ -33,53 +32,69 @@ frappe.ui.form.on('Mockup Design', {
         }
     }
 });
+
 frappe.ui.form.on('Properties', {
-  create_raw_material: function(frm, cdt , cdn) {
-    let row = locals[cdt][cdn];
-    frappe.new_doc('Raw Material Bundle', {
-      'reference_doctype': 'Properties',
-      'reference_name': row.name,
-    })
-  },
+    create_raw_material: function(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        frappe.new_doc('Raw Material Bundle', {
+            'reference_doctype': 'Properties',
+            'reference_name': row.name,
+        });
+    },
 
-  show_features: function(frm, cdt, cdn) {
-       /**
-       * Function to display features for a selected property.
-       * Fetches and displays feature details in a message box.
-       */
-      let row = locals[cdt][cdn];
-      frappe.call({
-          method: 'versa_system.versa_system.custom_scripts.lead.lead.fetch_feature_detail',
-          callback: function(response) {
-              if (response.message && response.message.length > 0) {
-                  let feature_html = '<table class="table table-bordered">';
-                  feature_html += '<tr><th>Attribute</th><th>Value</th></tr>';
-                  response.message.forEach(attr => {
-                      feature_html += `<tr><td>${attr.attribute}</td><td>${attr.value}</td></tr>`;
-                  });
+    show_features: function(frm, cdt, cdn) {
+        /**
+        * Function to display features for a selected property.
+        * Fetches and displays feature details in a message box.
+        */
+        let row = locals[cdt][cdn];
+        frappe.call({
+            method: 'versa_system.versa_system.custom_scripts.lead.lead.fetch_feature_detail',
+            args: {
+                property_name: row.name  // Ensure this argument is correctly passed if required by your method
+            },
+            callback: function(response) {
+                if (response.message && response.message.length > 0) {
+                    let feature_html = '<table class="table table-bordered">';
+                    feature_html += '<tr><th>Attribute</th><th>Value</th></tr>';
+                    response.message.forEach(attr => {
+                        feature_html += `<tr><td>${attr.attribute}</td><td>${attr.value}</td></tr>`;
+                    });
 
-                  feature_html += '</table>';
+                    feature_html += '</table>';
 
-                  frappe.msgprint({
-                      title: 'Features',
-                      message: feature_html
-                  });
-              } else {
-                  frappe.msgprint(__('No Features available for this Properties.'));
-              }
-          }
-    });
-}
+                    frappe.msgprint({
+                        title: 'Features',
+                        message: feature_html
+                    });
+                } else {
+                    frappe.msgprint(__('No Features available for this property.'));
+                }
+            }
+        });
+    }
 });
+
 frappe.ui.form.on('Mockup Design', {
     onload: function(frm) {
         frm.set_query('from_lead', function() {
             return {
-              "filters":{
-                Status :'Feasibility check Approved'
-              }
-
+                filters: {
+                    Status: ['in', ['Feasibility Check Approved', 'Quotation']]
+                }
             };
         });
+    }
+});
+
+frappe.ui.form.on('Mockup Design', {
+    refresh: function(frm) {
+        if (frm.doc.properties) {
+
+            // Update docfield properties to hide the fields
+            frm.fields_dict.properties.grid.update_docfield_property('final_design', 'hidden', 1);
+            frm.fields_dict.properties.grid.update_docfield_property('create_size_chart', 'hidden', 1);
+            frm.fields_dict.properties.grid.update_docfield_property('create_features', 'hidden', 1);
+        }
     }
 });

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -8,17 +8,10 @@
  "field_order": [
   "from_lead",
   "column_break_xuvm",
-  "image",
   "section_break_mfrw",
   "properties"
  ],
  "fields": [
-  {
-   "fieldname": "image",
-   "fieldtype": "Attach Image",
-   "label": "Mockup Design",
-   "reqd": 1
-  },
   {
    "fieldname": "from_lead",
    "fieldtype": "Link",
@@ -31,8 +24,7 @@
    "fieldname": "properties",
    "fieldtype": "Table",
    "label": "Properties",
-   "options": "Properties Table",
-   "read_only": 1
+   "options": "Properties Table"
   },
   {
    "fieldname": "column_break_xuvm",
@@ -43,10 +35,9 @@
    "fieldtype": "Section Break"
   }
  ],
- "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-20 17:19:35.105572",
+ "modified": "2024-06-24 15:01:29.428604",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",

--- a/versa_system/versa_system/doctype/properties_table/properties_table.json
+++ b/versa_system/versa_system/doctype/properties_table/properties_table.json
@@ -15,7 +15,9 @@
   "column_break_aizn",
   "create_size_chart",
   "show_features",
-  "create_features"
+  "create_features",
+  "mockup_design",
+  "final_design"
  ],
  "fields": [
   {
@@ -69,12 +71,22 @@
   {
    "fieldname": "column_break_aizn",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "mockup_design",
+   "fieldtype": "Attach",
+   "label": "Mockup Design"
+  },
+  {
+   "fieldname": "final_design",
+   "fieldtype": "Attach",
+   "label": "Final Design"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-20 17:09:58.376970",
+ "modified": "2024-06-24 14:39:56.667900",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Properties Table",


### PR DESCRIPTION
## Issue description
Hidding some fields of child table in particular doctype.

## Analysis and design (optional)
Hidding some fields of properties_table in some doctype

## Solution description
Hidded Field of child table Mockup and Final design attach in Lead and mockup .

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/0f5211d5-b354-4617-abd7-760c09d4a0c6)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/0bed7312-27a3-43b3-9bee-6230157289b0)


## Areas affected and ensured
Doctype - Mockup and Lead

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
