### PR TITLE
fix:Validated to Allow to save the Feasibility Check Doctype  without checking Goforward checkbox.

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -136,12 +136,9 @@ frappe.ui.form.on('Feasibility Check', {
     },
 
     go_forward: function(frm) {
-        // Update all child checkboxes based on the parent checkbox
         frm.doc.properties.forEach(function(row) {
             frappe.model.set_value(row.doctype, row.name, 'go_forward', frm.doc.go_forward ? 1 : 0);
         });
-
-        // Save the form after updating checkboxes if needed
         if (!frm.doc.__unsaved) {
             frm.save('Update').then(function() {
                 frm.approve();
@@ -150,24 +147,18 @@ frappe.ui.form.on('Feasibility Check', {
     },
 
     validate: function(frm) {
-        // Ensure at least one "Go Forward" checkbox is selected
+      /*
+      *  Allow  to save the form without checking the "go forward" checkbox.
+      */
         var atLeastOneChecked = frm.doc.properties.some(function(row) {
             return row.go_forward;
         });
-
-        if (!atLeastOneChecked) {
-            frappe.msgprint("At least one 'Go Forward' checkbox must be selected.");
-            frappe.validated = false;
-        }
     }
 });
-
 
 function set_parent_go_forward_checkbox(frm) {
     var atLeastOneChecked = frm.doc.properties.some(function(row) {
         return row.go_forward;
     });
-
-    // Set the parent checkbox accordingly
     frm.set_value('go_forward', atLeastOneChecked);
 }


### PR DESCRIPTION
##  Issue description
Need to Validate to Allow to save the Feasibility Check Doctype  without checking Goforward checkbox.

## Analysis and design (optional)
Need to Allow to save the Feasibility check Doctype without checking Goforward checkbox.

## Solution description
Allowed to save the Feasibility check Doctype without checking the Goforward checkbox.

## Output screenshots (optional)
[Screencast from 26-06-24 11:53:25 AM IST.webm](https://github.com/efeoneAcademy/versa_system/assets/170389963/859230e9-c6d9-45fe-8f73-dc3e1fdd2698)

## Areas affected and ensured
Allowed to save the Feasibility Check Doctype without checking Goforward  checkbox.

## Is there any existing behavior change of other features due to this code change?
Feasibilty Check Doctype

## Was this feature tested on the browsers
  - Mozilla Firefox
  