### PR TITLE
fix:Validated to Allow to save the Feasibility Check Doctype without checking Goforward checkbox

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -175,3 +175,42 @@ frappe.ui.form.on('Feasibility Solution', {
         });
     }
 });
+
+frappe.ui.form.on('Feasibility Check', {
+    onload: function(frm) {
+        frm.fields_dict.properties.grid.on('render', function() {
+            frm.fields_dict.properties.grid.grid_rows.forEach(function(row) {
+                row.get_field('go_forward').$input.on('change', function() {
+                    set_parent_go_forward_checkbox(frm);
+                });
+            });
+        });
+    },
+
+    go_forward: function(frm) {
+        frm.doc.properties.forEach(function(row) {
+            frappe.model.set_value(row.doctype, row.name, 'go_forward', frm.doc.go_forward ? 1 : 0);
+        });
+        if (!frm.doc.__unsaved) {
+            frm.save('Update').then(function() {
+                frm.approve();
+            });
+        }
+    },
+
+    validate: function(frm) {
+      /*
+      *  Allow  to save the form without checking the "go forward" checkbox.
+      */
+        var atLeastOneChecked = frm.doc.properties.some(function(row) {
+            return row.go_forward;
+        });
+    }
+});
+
+function set_parent_go_forward_checkbox(frm) {
+    var atLeastOneChecked = frm.doc.properties.some(function(row) {
+        return row.go_forward;
+    });
+    frm.set_value('go_forward', atLeastOneChecked);
+}


### PR DESCRIPTION

## Issue description
Clearly and concisely describe the feature.

## Analysis and design (optional)
Need to Validate to Allow to save the Feasibility Check Doctype without checking Goforward checkbox.

## Solution description
Need to Allow to save the Feasibility check Doctype without checking Goforward checkbox.

## Output screenshots (optional)
[Screencast from 26-06-24 11:53:25 AM IST.webm](https://github.com/efeoneAcademy/versa_system/assets/170389963/90cc3211-2636-4984-a083-2e139c21d112)


## Areas affected and ensured
Allowed to save the Feasibility Check Doctype without checking Goforward checkbox

## Is there any existing behavior change of other features due to this code change?
Feasibilty Check Doctype

## Was this feature tested on the browsers?
  - Mozilla Firefox
  
