### PR TITLE
fix : Hidding field of child table

### DIFF
--- a/versa_system/versa_system/doctype/final_design/final_design.js
+++ b/versa_system/versa_system/doctype/final_design/final_design.js
@@ -133,6 +133,8 @@ frappe.ui.form.on('Final Design', {
             // Update docfield properties to hide the fields
             frm.fields_dict.properties.grid.update_docfield_property('create_size_chart', 'hidden', 1);
             frm.fields_dict.properties.grid.update_docfield_property('create_features', 'hidden', 1);
+            frm.fields_dict.properties.grid.update_docfield_property('low_range', 'hidden', 1);
+            frm.fields_dict.properties.grid.update_docfield_property('high_range', 'hidden', 1);
         }
     }
 });

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -95,6 +95,8 @@ frappe.ui.form.on('Mockup Design', {
             frm.fields_dict.properties.grid.update_docfield_property('final_design', 'hidden', 1);
             frm.fields_dict.properties.grid.update_docfield_property('create_size_chart', 'hidden', 1);
             frm.fields_dict.properties.grid.update_docfield_property('create_features', 'hidden', 1);
+            frm.fields_dict.properties.grid.update_docfield_property('low_range', 'hidden', 1);
+            frm.fields_dict.properties.grid.update_docfield_property('high_range', 'hidden', 1);
         }
     }
 });


### PR DESCRIPTION
## Issue description
Hidding Fields of chld table in particular doctype.

## Analysis and design (optional)
Hidding fields in doctype mockup and final design

## Solution description
Hidded fields of the child table in doctype mockup and final design

## Output screenshots (optional)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/1f13b249-036a-410a-8b26-02df5ada6ee0)
![image](https://github.com/efeoneAcademy/versa_system/assets/117623626/0ddc351a-2b52-448d-b991-79f6c0f9df57)


## Areas affected and ensured
Doctype - Mockup Design and Final Design.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
