### PR TITLE
Only checked rows mapped to mockup from feasibility

### DIFF
--- a/versa_system/versa_system/custom_scripts/lead/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead/lead.py
@@ -75,23 +75,23 @@ def map_lead_to_mockup_design(source_name, target_doc=None):
        Output: data from lead is mapped to a new mockup design document
     """
     def set_missing_values(source, target):
-        pass
+        if frappe.db.exists("Feasibility Check", {"from_lead":source.name}):
+            feasibility_doc = frappe.get_doc("Feasibility Check", {"from_lead":source.name})
+            for row in feasibility_doc.properties:
+                if row.go_forward:
+                    target.append("properties", {
+                        'item_type': row.item_type,
+                        'item_code': row.item_code,
+                        'quantity' : row.quantity,
+                    })
+
+
 
     target_doc = get_mapped_doc("Lead", source_name,
     {
         "Lead": {
             "doctype": "Mockup Design",
             "field_map": {
-            },
-        },
-        "Properties Table": {
-            "doctype": "Properties Table",
-            "field_map": {
-                'item_type'  : 'item_type',
-                 'item_code' : 'item_code',
-                 'quantity'  : 'quantity',
-                 'low_range' : 'low_range',
-                 'high_range': 'high_range'
             },
         },
     }, target_doc, set_missing_values)
@@ -226,7 +226,7 @@ def fetch_raw_material_details(reference=None):
 
 @frappe.whitelist()
 def fetch_feature_detail():
-    ''' 
+    '''
         Method: Fetches all feature details.
 
         Output: Returns a list containing Feature details


### PR DESCRIPTION
## Issue description
Only checked rows mapped to mockup from feasibility.

## Analysis and design (optional)
Only data from feasibiity row checked should map to mockup

## Solution description
set as rows of feasibility check fetch to mockup if only if it is checked the go_forward checkbox.

## Output screenshots (optional)
.
[Screencast from 26-06-24 12:52:08 PM IST.webm](https://github.com/efeoneAcademy/versa_system/assets/117623626/f1f500a0-bc05-4a69-9364-2fd8de6969e8)


## Areas affected and ensured.
Doctype - Mockup

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox- yes
  - Opera Mini
  - Safari
