### PR TITLE
fix:Validated to Allow to save the Feasibility Check Doctype without checking Goforward checkbox.

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -60,11 +60,6 @@ frappe.ui.form.on('Feasibility Check', {
         var atLeastOneChecked = frm.doc.properties.some(function(row) {
             return row.go_forward;
         });
-
-        if (!atLeastOneChecked) {
-            frappe.msgprint("At least one 'Go Forward' checkbox must be selected.");
-            frappe.validated = false;
-        }
     }
 });
 


### PR DESCRIPTION


## Issue description
Clearly and concisely describe the feature.

## Analysis and design (optional)
Need to Validate to Allow to save the Feasibility Check Doctype without checking Goforward checkbox.

## Solution description
Need to Allow to save the Feasibility check Doctype without checking Goforward checkbox

## Output screenshots (optional)
[Screencast from 26-06-24 11:53:25 AM IST.webm](https://github.com/efeoneAcademy/versa_system/assets/170389963/baf4b97f-1b79-47a1-b022-9d31a5044252)

## Areas affected and ensured
Allowed to save the Feasibility Check Doctype without checking Goforward checkbox

## Is there any existing behavior change of other features due to this code change?
Feasibilty Check Doctype

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  
