### PR TITLE
fix: Automatic fetching of mockup design to final design doctype.

### DIFF
--- a/versa_system/versa_system/doctype/final_design/final_design.js
+++ b/versa_system/versa_system/doctype/final_design/final_design.js
@@ -128,13 +128,13 @@ frappe.ui.form.on('Final Design', {
 
 frappe.ui.form.on('Final Design', {
     refresh: function(frm) {
-        if (frm.doc.properties) {
+        if (frm.doc.properties_table) {
 
             // Update docfield properties to hide the fields
-            frm.fields_dict.properties.grid.update_docfield_property('create_size_chart', 'hidden', 1);
-            frm.fields_dict.properties.grid.update_docfield_property('create_features', 'hidden', 1);
-            frm.fields_dict.properties.grid.update_docfield_property('low_range', 'hidden', 1);
-            frm.fields_dict.properties.grid.update_docfield_property('high_range', 'hidden', 1);
+            frm.fields_dict.properties_table.grid.update_docfield_property('create_size_chart', 'hidden', 1);
+            frm.fields_dict.properties_table.grid.update_docfield_property('create_features', 'hidden', 1);
+            frm.fields_dict.properties_table.grid.update_docfield_property('low_range', 'hidden', 1);
+            frm.fields_dict.properties_table.grid.update_docfield_property('high_range', 'hidden', 1);
         }
     }
 });

--- a/versa_system/versa_system/doctype/final_design/final_design.json
+++ b/versa_system/versa_system/doctype/final_design/final_design.json
@@ -9,9 +9,7 @@
   "from_lead",
   "column_break_edmg",
   "section_break_hcmb",
-  "properties_table",
-  "section_break_ipql",
-  "quotation_items"
+  "properties_table"
  ],
  "fields": [
   {
@@ -27,18 +25,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "quotation_items",
-   "fieldtype": "Table",
-   "label": "Quotation Items",
-   "options": "Quotation Item",
-   "read_only": 1
-  },
-  {
    "fieldname": "section_break_hcmb",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "section_break_ipql",
    "fieldtype": "Section Break"
   },
   {
@@ -50,7 +37,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-25 12:29:59.134512",
+ "modified": "2024-06-26 14:55:15.715032",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Final Design",

--- a/versa_system/versa_system/doctype/properties_table/properties_table.json
+++ b/versa_system/versa_system/doctype/properties_table/properties_table.json
@@ -86,7 +86,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-24 14:39:56.667900",
+ "modified": "2024-06-26 16:37:45.529726",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Properties Table",


### PR DESCRIPTION
## Feature description
Need for Automatic Fetching of Mockup Design to Final Design Doctype.

## Solution description
Fetched Mockup design on Final Design Doctype.
Fetched item name to the quotation.
Hidden some Fields in the Doctype.

##Output screenshots (optional)
[Screencast from 06-27-2024 11:34:01 AM.webm](https://github.com/efeoneAcademy/versa_system/assets/118014735/e1ff6b0d-0f1b-48e7-bbe9-c1c4fdc05fa0)
[Screencast from 06-27-2024 11:36:41 AM.webm](https://github.com/efeoneAcademy/versa_system/assets/118014735/0c45cdd8-0607-42ab-84dc-68212ae16f0a)

## Areas affected and ensured
Final Design Doctype.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox