### PR TITLE
Created A Button Mockup Design From Lead

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -1,3 +1,4 @@
+
 frappe.ui.form.on('Lead', {
     refresh: function(frm) {
         frm.add_custom_button(__('Feasibility Check'), function() {
@@ -13,6 +14,14 @@ frappe.ui.form.on('Lead', {
                 frm: frm
             });
         }, __('Create'));
+        
+        frm.add_custom_button(__('Mockup Design'), function() {
+             frappe.model.open_mapped_doc({
+                 method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_mockup_design',
+                 frm: frm
+             });
+         }, __('Create'));
+
 
         setTimeout(() => {
             frm.remove_custom_button('Quotation', 'Create');

--- a/versa_system/versa_system/custom_scripts/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead.py
@@ -4,45 +4,84 @@ from frappe.model.mapper import get_mapped_doc
 @frappe.whitelist()
 def map_lead_to_feasibility_check(source_name, target_doc=None):
     """
-    Map fields from the Lead DocType to Feasibility Check DocType.
-    
-    Parameters:
-        source_name (str): The name of the Lead document to be mapped.
-        target_doc (Document, optional): An existing target document to map to. Defaults to None.
-    
-    Returns:
-        Document: The mapped target document.
+    Map fields from Lead DocType to Feasibility Check DocType.
     """
+    def set_missing_values(source, target):
+        target.from_lead = source.name
+        target.material = source.custom_material_type
 
-    # Use get_mapped_doc to map fields from Lead to Feasibility Check and related DocTypes
+
+
     target_doc = get_mapped_doc("Lead", source_name,
         {
             "Lead": {
                 "doctype": "Feasibility Check",
                 "field_map": {
-                    "first_name": "from_lead"
-                    
+                    "first_name": "from_lead",
+                    'custom_material_type': 'material'
+
                 },
             },
-            "Properties": {                               
+            "Properties": {
                 "doctype": "Properties",
                 "field_map": {
-                    'finishing': 'finishing',  
+                    'finishing': 'finishing',
                     'color': 'color',
-                    'material': 'material'
+                    # 'material': 'material'
                 },
             },
-            "Size Chart": {                               
+            "Size Chart": {
                 "doctype": "Size Chart",
                 "field_map": {
-                    'size': 'size',          
+                    'size': 'size',
                     'dimensions': 'dimensions'
                 },
             },
-        }, target_doc)
+        }, target_doc, set_missing_values)
 
-    
-    if not target_doc:
-        frappe.throw("Target document could not be created.")
+    return target_doc
+
+@frappe.whitelist()
+def map_lead_to_quotation(source_name, target_doc=None):
+    """
+    Map fields from Lead DocType to Quotation DocType.
+    """
+    def set_missing_values(source, target):
+        target.quotation_to = "Lead"
+        target.party_name = source.name
+
+    target_doc = get_mapped_doc("Lead", source_name,
+        {
+            "Lead": {
+                "doctype": "Quotation",
+                "field_map": {
+                    "name": "party_name"
+                },
+            },
+        }, target_doc, set_missing_values)
+
+    return target_doc
+
+@frappe.whitelist()
+def map_lead_to_mockup_design(source_name, target_doc=None):
+    """
+    Map fields from Lead DocType to Mockup Design DocType.
+    """
+    def set_missing_values(source, target):
+        target.mockup_design_to = "Lead"
+        target.from_lead = source.name
+        if hasattr(source, 'custom_images'):
+            target.custom_images = source.custom_images  # Assuming you want to map this field
+
+    target_doc = get_mapped_doc("Lead", source_name,
+    {
+        "Lead": {
+            "doctype": "Mockup Design",
+            "field_map": {
+                "first_name": "from_lead",
+                "custom_material_type": "material_type"
+            },
+        },
+    }, target_doc, set_missing_values)
 
     return target_doc

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -37,7 +37,7 @@
    "fieldname": "material",
    "fieldtype": "Link",
    "label": "Material Type",
-   "options": "Lead"
+   "options": "Material Type"
   },
   {
    "fieldname": "availability_of_materials",
@@ -52,7 +52,8 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-20 15:57:12.207174",
+ "modified": "2024-09-24 13:12:25.156646",
+
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Check",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -36,13 +36,18 @@
    "fieldname": "material_type",
    "fieldtype": "Link",
    "label": "Material Type",
-   "options": "Lead"
-  }
+
+
+   "options": "Material Type"
+  },
+
+
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-23 12:19:50.534554",
+
+ "modified": "2024-09-23 14:59:00.119269",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",


### PR DESCRIPTION
## Feature description
 Create a button from Lead to Mockup Design and map the lead data to mockup design
## Solution description
Mockup design button created in lead doctype and mapped the lead data to mockup design doctype.
In feasibility doctype ,changed the material type feild's link option lead as material type

## Output
![image](https://github.com/user-attachments/assets/79a8c342-f8e2-4bab-9dfa-97d341596615)
![image](https://github.com/user-attachments/assets/b6acd7da-832a-4091-abad-3632e77160b1)
![image](https://github.com/user-attachments/assets/1befa712-25df-4647-9de5-301e153d9f6a)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox