### PR TITLE
Fix the Quotation Work Flow action Review to Revision Request

### DIFF
--- a/versa_system/fixtures/workflow_action_master.json
+++ b/versa_system/fixtures/workflow_action_master.json
@@ -2,13 +2,6 @@
  {
   "docstatus": 0,
   "doctype": "Workflow Action Master",
-  "modified": "2024-09-12 16:27:37.123867",
-  "name": "Review",
-  "workflow_action_name": "Review"
- },
- {
-  "docstatus": 0,
-  "doctype": "Workflow Action Master",
   "modified": "2024-09-12 16:27:37.121348",
   "name": "Approve",
   "workflow_action_name": "Approve"
@@ -26,5 +19,12 @@
   "modified": "2024-09-20 12:10:35.358455",
   "name": "Sent to Customer",
   "workflow_action_name": "Sent to Customer"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow Action Master",
+  "modified": "2024-09-27 15:37:26.501768",
+  "name": "Rivision Requested",
+  "workflow_action_name": "Rivision Requested"
  }
 ]

--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -244,7 +244,7 @@ fixtures = [
     {
         "dt": "Workflow Action Master",
         "filters": [
-            ["name", "in", ["Approve", "Reject", "Review","Sent to Customer"]]
+            ["name", "in", ["Approve", "Reject", "Rivision Requested","Sent to Customer"]]
         ]
     }
 ]

--- a/versa_system/versa_system/doctype/material_type/material_type.json
+++ b/versa_system/versa_system/doctype/material_type/material_type.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:item_type",
+ "autoname": "field:item_type",
  "creation": "2024-09-17 11:36:42.235990",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -17,17 +17,17 @@
   {
    "fieldname": "item_type",
    "fieldtype": "Data",
-   "label": "Item Type"
+   "label": "Item Type",
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
- "is_submittable": 1,
  "links": [],
- "modified": "2024-09-23 15:46:08.911097",
+ "modified": "2024-09-30 12:17:03.375404",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Material Type",
- "naming_rule": "Expression",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -40,7 +40,6 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
-   "submit": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
## Feature description
Fix the  Quotation Work Flow Action Review to Revision Requested 
Update the Naming series
Change the feild type 
Fix the lead doctype "create" button is visible after the lead is saved  


## Solution description
Fixed the Quotation Work Flow Action Review to Revision Requested.
Updated the Naming series of Material Doctype. 
Changed the feild type link  to data of feild material in Feasibility Check doctype.
In lead doctype create button is visible after the lead is saved
## Output
![image](https://github.com/user-attachments/assets/9d37d90a-7512-483a-b329-e183e680fe49)
![image](https://github.com/user-attachments/assets/0a8a5ced-2c4d-4a5d-8e5c-1c8ae7f48816)
![image](https://github.com/user-attachments/assets/22164b43-31bd-463a-a9cf-de593126d386)
![image](https://github.com/user-attachments/assets/9dc0e401-f0cf-47d4-bf4c-bea1bf86f12a)



## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox