### PR TITLE
Fix the lead doctype create button is visible after the lead is saved

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -1,33 +1,35 @@
-
 frappe.ui.form.on('Lead', {
     refresh: function(frm) {
-        frm.add_custom_button(__('Feasibility Check'), function() {
-            frappe.model.open_mapped_doc({
-                method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_feasibility_check',
-                frm: frm
-            });
-        }, __('Create'));
+        // Check if the lead is already saved
+        if (!frm.is_new()) {
+            frm.add_custom_button(__('Feasibility Check'), function() {
+                frappe.model.open_mapped_doc({
+                    method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_feasibility_check',
+                    frm: frm
+                });
+            }, __('Create'));
 
-        frm.add_custom_button(__('New Quotation'), function() {
-            frappe.model.open_mapped_doc({
-                method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_quotation',
-                frm: frm
-            });
-        }, __('Create'));
-        
-        frm.add_custom_button(__('Mockup Design'), function() {
-             frappe.model.open_mapped_doc({
-                 method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_mockup_design',
-                 frm: frm
-             });
-         }, __('Create'));
+            frm.add_custom_button(__('New Quotation'), function() {
+                frappe.model.open_mapped_doc({
+                    method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_quotation',
+                    frm: frm
+                });
+            }, __('Create'));
 
+            frm.add_custom_button(__('Mockup Design'), function() {
+                frappe.model.open_mapped_doc({
+                    method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_mockup_design',
+                    frm: frm
+                });
+            }, __('Create'));
 
-        setTimeout(() => {
-            frm.remove_custom_button('Quotation', 'Create');
-            frm.remove_custom_button('Customer', 'Create');
-            frm.remove_custom_button('Prospect', 'Create');
-            frm.remove_custom_button('Opportunity', 'Create');
-        }, 10);
+            // Removing default buttons
+            setTimeout(() => {
+                frm.remove_custom_button('Quotation', 'Create');
+                frm.remove_custom_button('Customer', 'Create');
+                frm.remove_custom_button('Prospect', 'Create');
+                frm.remove_custom_button('Opportunity', 'Create');
+            }, 10);
+        }
     }
 });

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -33,11 +33,9 @@
    "options": "Size Chart"
   },
   {
-   "fetch_from": "from_lead.custom_material_type",
    "fieldname": "material",
-   "fieldtype": "Link",
-   "label": "Material Type",
-   "options": "Material Type"
+   "fieldtype": "Data",
+   "label": "Material Type"
   },
   {
    "fieldname": "availability_of_materials",
@@ -52,8 +50,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-24 13:12:25.156646",
-
+ "modified": "2024-09-27 15:24:29.536888",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Check",

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -4,13 +4,15 @@ from frappe.model.document import Document
 class FeasibilityCheck(Document):
 
     def on_update(self):
-        "IF the feasibility Check is Approved then the moc design will be created "
+        "IF the feasibility Check is Approved then the mockup design will be created "
         if self.workflow_state == 'Approved':
-                    moc_design = frappe.get_doc({
-                        'doctype': 'Mockup Design',
-                        'from_lead': self.from_lead
-                    })
-                    
-                    moc_design.insert(ignore_permissions=True)
-                    frappe.msgprint(f'Mockup Design {moc_design.from_lead} created successfully.')
-                
+            # Create the Mockup Design document
+            moc_design = frappe.get_doc({
+                'doctype': 'Mockup Design',
+                'from_lead': self.from_lead,
+                'material': self.material  # Fetching material data from FeasibilityCheck
+            })
+
+            # Insert the new Mockup Design document
+            moc_design.insert(ignore_permissions=True)
+            frappe.msgprint(f'Mockup Design {moc_design.from_lead} created successfully.')


### PR DESCRIPTION
## Feature description
Change the feild type
Fix the lead doctype "create" button is visible after the lead is saved
## Solution description
Changed the feild type link to data of feild material in Feasibility Check doctype.
In lead doctype create button is visible after the lead is saved

## Output
![image](https://github.com/user-attachments/assets/18a79327-30c7-4f91-bbc3-74f38068457c)
![image](https://github.com/user-attachments/assets/cf13c6e7-480a-4a31-a445-d680bc90e4af)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox 

  