### PR TITLE
feat: item filtering based on Item Group

### DIFF
--- a/versa_system/versa_system/doctype/raw_material/raw_material.js
+++ b/versa_system/versa_system/doctype/raw_material/raw_material.js
@@ -1,0 +1,21 @@
+frappe.ui.form.on("Raw Material", {
+  refresh: function (frm) {
+    // Filter for Item Type field (show only Products)
+    frm.set_query("item_type", function () {
+      return {
+        filters: {
+          item_group: "Products", // Filter for items that belong to "Products"
+        },
+      };
+    });
+
+    // Filter for Material field (show only Raw Materials)
+    frm.set_query("material", function () {
+      return {
+        filters: {
+          item_group: "Raw Material", // Filter for items that belong to "Raw Material"
+        },
+      };
+    });
+  },
+});

--- a/versa_system/versa_system/doctype/raw_material/raw_material.json
+++ b/versa_system/versa_system/doctype/raw_material/raw_material.json
@@ -11,7 +11,7 @@
   "column_break_wdg6",
   "material",
   "section_break_qpey",
-  "resources"
+  "raw_material"
  ],
  "fields": [
   {
@@ -27,23 +27,23 @@
    "options": "Item"
   },
   {
-   "fieldname": "resources",
-   "fieldtype": "Table",
-   "label": "Raw Material",
-   "options": "Raw materials"
-  },
-  {
    "fieldname": "column_break_wdg6",
    "fieldtype": "Column Break"
   },
   {
    "fieldname": "section_break_qpey",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "raw_material",
+   "fieldtype": "Table",
+   "label": "Raw Material",
+   "options": "Raw materials"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-30 15:24:09.310952",
+ "modified": "2024-10-02 12:16:59.412470",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material",


### PR DESCRIPTION
## Feature description
Implemented item filtering functionality in the "Item Code" and "Material" fields.
## Solution description
Added item filtering logic for "Item Code" and "Material" fields based on the selected "Item Group."
- Only items marked as "Products" are shown in the "Item Code" field.
- Only items marked as "Raw Material" are shown in the "Material" field.
- Only active (non-disabled) items are displayed in both fields.
## Output
![image](https://github.com/user-attachments/assets/0626f7ad-5995-47ac-b16b-a81eda6014b3)
![image](https://github.com/user-attachments/assets/939b4591-eb24-4c39-bf5c-515a3937cce3)


## Areas affected and ensured
- New feature added for filtering items.
- No existing features or behaviors were impacted by the changes.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Windows Edge.