### PR TITLE
Created custom button for Mockup Design to Quotation

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -16,14 +16,7 @@ frappe.ui.form.on('Lead', {
                 });
             }, __('Create'));
 
-            frm.add_custom_button(__('Mockup Design'), function() {
-                frappe.model.open_mapped_doc({
-                    method: 'versa_system.versa_system.custom_scripts.lead.map_lead_to_mockup_design',
-                    frm: frm
-                });
-            }, __('Create'));
-
-            // Removing default buttons
+      
             setTimeout(() => {
                 frm.remove_custom_button('Quotation', 'Create');
                 frm.remove_custom_button('Customer', 'Create');

--- a/versa_system/versa_system/custom_scripts/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead.py
@@ -15,9 +15,7 @@ def map_lead_to_feasibility_check(source_name, target_doc=None):
         {
             "Lead": {
                 "doctype": "Feasibility Check",
-                "field_map": {
-                
-                },
+                "field_map": {},
             },
             "Enqury Details": {  # Ensure that 'Enquiry Details' is the correct child table name
                 "doctype": "Enqury Details",  # Ensure this matches the target child table
@@ -51,38 +49,6 @@ def map_lead_to_quotation(source_name, target_doc=None):
                 "doctype": "Quotation",
                 "field_map": {
                     "name": "party_name"
-                },
-            },
-        }, target_doc, set_missing_values)
-
-    return target_doc
-
-@frappe.whitelist()
-def map_lead_to_mockup_design(source_name, target_doc=None):
-    """
-    Map fields from Lead DocType to Mockup Design DocType.
-    """
-    def set_missing_values(source, target):
-        target.mockup_design_to = "Lead"
-        target.from_lead = source.name
-        if hasattr(source, 'custom_images'):
-            target.custom_images = source.custom_images  # Assuming you want to map this field
-
-    target_doc = get_mapped_doc("Lead", source_name,
-        {
-            "Lead": {
-                "doctype": "Mockup Design",
-                "field_map": {
-                    "first_name": "from_lead",
-                    "custom_material_type": "material_type"
-                },
-            },
-            "Properties": {
-                "doctype": "Properties",
-                "field_map": {
-                    'finishing': 'finishing',
-                    'color': 'color',
-                    'material': 'material'
                 },
             },
         }, target_doc, set_missing_values)

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -6,13 +6,10 @@ class FeasibilityCheck(Document):
     def on_update(self):
         "IF the feasibility Check is Approved then the mockup design will be created "
         if self.workflow_state == 'Approved':
-            # Create the Mockup Design document
+
             moc_design = frappe.get_doc({
                 'doctype': 'Mockup Design',
                 'from_lead': self.from_lead,
-                'material': self.material  # Fetching material data from FeasibilityCheck
             })
 
-            # Insert the new Mockup Design document
             moc_design.insert(ignore_permissions=True)
-            frappe.msgprint(f'Mockup Design {moc_design.from_lead} created successfully.')

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -1,8 +1,14 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
-
-// frappe.ui.form.on("Mockup Design", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on('Mockup Design', {
+    refresh: function(frm) {
+        // Check if the workflow state is "Approved"
+        if (frm.doc.workflow_state === 'Approved') {
+            frm.add_custom_button(__('Quotation'), function() {
+                // Call the mapping function for Mockup Design to Quotation
+                frappe.model.open_mapped_doc({
+                    method: 'versa_system.versa_system.doctype.mockup_design.mockup_design.map_mockup_design_to_quotation',
+                    frm: frm
+                });
+            }, __('Create'));
+        }
+    }
+});

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -1,10 +1,29 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe.model.mapper import get_mapped_doc
 
 class MockupDesign(Document):
-	pass
+    pass
 
+@frappe.whitelist()
+def map_mockup_design_to_quotation(source_name, target_doc=None):
+    """
+    Map fields from Mockup Design DocType to Quotation DocType.
+    """
+    def set_missing_values(source, target):
+        target.quotation_to = "Mockup Design"
+        target.party_name = source.from_lead
+
+    target_doc = get_mapped_doc("Mockup Design", source_name,
+        {
+            "Mockup Design": {
+                "doctype": "Quotation",
+                "field_map": {
+                    "from_lead": "party_name"
+                },
+            },
+        }, target_doc, set_missing_values)
+
+    return target_doc


### PR DESCRIPTION
## Feature description
Need to : Create a Custom Button for Mockup Design to Quotation Doctype and Map the data
                Delete the Mapping from lead Doctype to Mockup Design Doctype
                Delete the material feild while mapping from Feasibility Check Doctype to Mockup Design Doctype
## Solution description
Created a Custom Button for  Mockup Design to Quotation Doctype and Mapped the data
Deleted the mapping process from lead Doctype to Mockup Design Doctype
Deleted material feild while mapping from Feasibility Check Doctype to Mockup Design Doctype
## Output
![image](https://github.com/user-attachments/assets/963daf99-12c3-4abf-acbd-0bc1832ef356)
![image](https://github.com/user-attachments/assets/ec6dbcd5-8568-4094-b784-29ee57eee9e5)
![image](https://github.com/user-attachments/assets/b2651684-7ae4-475e-ab4e-4301c0a79b54)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox