### PR TITLE
Mapped Lead data from Feasibility Check Doctype to Mockup Design Doctype

### DIFF
--- a/versa_system/versa_system/custom_scripts/quotation.py
+++ b/versa_system/versa_system/custom_scripts/quotation.py
@@ -5,7 +5,7 @@ from frappe.model.mapper import get_mapped_doc
 def map_quotation_to_final_design(source_name, target_doc=None):
     """
     Method to map a Quotation to a Final Design document.
-    
+
     Args:
         source_name: The name of the Quotation document to be mapped.
         target_doc: The target document to which the Quotation should be mapped.
@@ -22,7 +22,7 @@ def map_quotation_to_final_design(source_name, target_doc=None):
             "Quotation": {
                 "doctype": "Final Design",
                 "field_map": {
-                    "customer_name": "lead"
+                    "party_name": "lead"
                     # Add other field mappings here if necessary
                 },
             },

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -1,26 +1,13 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
-
 frappe.ui.form.on('Feasibility Check', {
     refresh: function(frm) {
+        // Check if the Feasibility Check is not new and is approved
         if (frm.doc.workflow_state === 'Approved') {
             frm.add_custom_button(__('Mockup Design'), function() {
-                frappe.call({
-                    method: 'frappe.client.insert',
-                    args: {
-                        doc: {
-                            doctype: 'Mockup Design',
-                            from_lead: frm.doc.from_lead
-                        }
-                    },
-                    callback: function(r) {
-                        if (r.message) {
-                            // Redirect to the newly created Mockup Design
-                            frappe.set_route('Form', 'Mockup Design', r.message.name);
-                        }
-                    }
+                frappe.model.open_mapped_doc({
+                    method: 'versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_feasibility_to_mockup_design',
+                    frm: frm
                 });
-            });
+            }, __('Create'));
         }
     }
 });

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -1,15 +1,39 @@
 import frappe
 from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
 
 class FeasibilityCheck(Document):
+    pass
 
-    def on_update(self):
-        "IF the feasibility Check is Approved then the mockup design will be created "
-        if self.workflow_state == 'Approved':
+@frappe.whitelist()
+def map_feasibility_to_mockup_design(source_name, target_doc=None):
+    """
+    Map fields from Feasibility Check DocType to Mockup Design DocType,
+    including the child table 'Enquiry Details' and its data.
+    """
+    def set_missing_values(source, target):
+        # Set any missing values if needed
+        pass
 
-            moc_design = frappe.get_doc({
-                'doctype': 'Mockup Design',
-                'from_lead': self.from_lead,
-            })
+    target_doc = get_mapped_doc("Feasibility Check", source_name,
+        {
+            "Feasibility Check": {
+                "doctype": "Mockup Design",
+                "field_map": {}
+            },
+            "Enqury Details": {  # Mapping the child table
+                "doctype": "Enqury Details",  # Ensure this matches the target child table in Mockup Design
+                "field_map": {
+                    "item": "item",
+                    "material": "material",
+                    "brand": "brand",
+                    "model": "model",
+                    "rate_range": "rate_range",
+                    "size": "size",
+                    "colour": "colour",
+                    "design": "design",
+                }
+            }
+        }, target_doc, set_missing_values)
 
-            moc_design.insert(ignore_permissions=True)
+    return target_doc

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -9,7 +9,9 @@
   "section_break_pdm5",
   "from_lead",
   "column_break_dtei",
-  "image"
+  "image",
+  "section_break_xldq",
+  "lead_details"
  ],
  "fields": [
   {
@@ -30,12 +32,23 @@
   {
    "fieldname": "column_break_dtei",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_xldq",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "lead_details",
+   "fieldtype": "Table",
+   "label": "Lead Details",
+   "options": "Enqury Details",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-09 10:03:47.500999",
+ "modified": "2024-10-10 15:39:13.891682",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -14,8 +14,8 @@ def map_mockup_design_to_quotation(source_name, target_doc=None):
     """
     def set_missing_values(source, target):
         target.quotation_to = "Mockup Design"
-        target.party_name = source.from_lead
-
+        target.party_name = source.name
+        target.customer_name = source.from_lead
     target_doc = get_mapped_doc("Mockup Design", source_name,
         {
             "Mockup Design": {


### PR DESCRIPTION
## Feature description
Need to : Map Lead data from Feasibility Check Doctype to Mockup Design Doctype
                Map lead name to Quotation when Mockup is Approved.
                Change the Mockup Design Doctype by adding the child table
## Solution description
Mapped Lead data from Feasibility Check Doctype to Mockup Design Doctype
Mapped lead name to  customer name feild in Quotation Doctype when Mockup is Approved.
Changed the Mockup Design Doctype by adding the child table whose label is Lead Details
## Output
![image](https://github.com/user-attachments/assets/2b0b634b-012f-4cab-b6e9-29cfee79fbfe)
![image](https://github.com/user-attachments/assets/3d5f9be0-73c7-4d28-b9f2-0b1eaf7aa3f5)
![image](https://github.com/user-attachments/assets/cfed2404-d37c-49d9-bf5d-e5c16934a3aa)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox

