### PR TITLE
feat: Create Work Orders from Sales Orders

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -124,13 +124,11 @@ doctype_js = {"Lead" : "public/js/lead.js","Quotation" : "public/js/quotation.js
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-# 	"*": {
-# 		"on_update": "method",
-# 		"on_cancel": "method",
-# 		"on_trash": "method"
-# 	}
-# }
+doc_events = {
+   "Sales Order": {
+       "on_submit": "versa_system.versa_system.costom.castom.create_work_order_from_sales_order"
+   }
+}
 
 # Scheduled Tasks
 # ---------------

--- a/versa_system/versa_system/costom/castom.py
+++ b/versa_system/versa_system/costom/castom.py
@@ -1,0 +1,39 @@
+import frappe
+
+def create_work_order_from_sales_order(doc, method, is_from_sales_order=True):
+    # Check if the function is called from the Sales Order context
+    if not is_from_sales_order:
+        frappe.msgprint("Work Order creation is not triggered from Sales Order.")
+        return  # Exit if not creating from Sales Order
+
+    # Loop through items in the Sales Order
+    for item in doc.items:
+        # Check if the quantity is greater than zero
+        if item.qty > 0:
+            # Check if a Work Order already exists for this Sales Order and item
+            existing_work_order = frappe.db.exists("Work Order", {
+                "sales_order": doc.name,
+                "production_item": item.item_code
+            })
+            if existing_work_order:
+                frappe.msgprint(f"Work Order for {item.item_code} already exists.")
+                continue  # Skip creating if it already exists
+
+            # Create Work Order
+            work_order = frappe.new_doc("Work Order")
+            work_order.production_item = item.item_code  # Set the production item
+            work_order.qty = item.qty  # Set the quantity to manufacture
+            work_order.sales_order = doc.name  # Link the Work Order to the Sales Order
+            work_order.company = doc.company  # Set company same as Sales Order
+            
+            # Set the Work Order status to Draft
+            work_order.workflow_state = "Draft"  # Set state to Draft
+
+            # Optionally set additional fields as required
+            # work_order.some_field = value
+            
+            work_order.insert()  # Insert the Work Order in Draft state
+            frappe.msgprint(f"Work Order created for {item.item_code} in Draft state.")
+
+    # Commit the transaction to save the Work Order
+    frappe.db.commit()

--- a/versa_system/versa_system/costom/castom.py
+++ b/versa_system/versa_system/costom/castom.py
@@ -1,12 +1,16 @@
 import frappe
 
 def create_work_order_from_sales_order(doc, method, is_from_sales_order=True):
-    # Check if the function is called from the Sales Order context
+    """
+    Create Work Orders from Sales Order items,
+    linking the Sales Order to the Work Order and setting the Work Order status to Draft.
+    Skips creation if a Work Order for the item already exists.
+    """
+    
     if not is_from_sales_order:
         frappe.msgprint("Work Order creation is not triggered from Sales Order.")
-        return  # Exit if not creating from Sales Order
+        return
 
-    # Loop through items in the Sales Order
     for item in doc.items:
         # Check if the quantity is greater than zero
         if item.qty > 0:
@@ -34,6 +38,3 @@ def create_work_order_from_sales_order(doc, method, is_from_sales_order=True):
             
             work_order.insert()  # Insert the Work Order in Draft state
             frappe.msgprint(f"Work Order created for {item.item_code} in Draft state.")
-
-    # Commit the transaction to save the Work Order
-    frappe.db.commit()


### PR DESCRIPTION
## Feature description
Developed a function to create Work Orders from Sales Orders, automatically linking relevant items and setting the Work Order status to Draft.
## Solution description
The function checks for existing Work Orders for each item in the Sales Order, creates new Work Orders as needed, and ensures they are saved in Draft state.
## Output
![Screenshot 2024-10-16 145902](https://github.com/user-attachments/assets/9a70743d-255d-4bcd-af8b-7f157ced8305)
![Screenshot 2024-10-16 145953](https://github.com/user-attachments/assets/d4218376-9c02-492b-9db5-f380d2e7a866)

## Areas affected and ensured
-New feature for generating Work Orders from Sales Orders.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Windows Edge