### PR TITLE
feat: Added a filter to separate product and Raw materials

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -38,3 +38,27 @@ frappe.ui.form.on("Lead", {
     }
   },
 });
+
+frappe.ui.form.on('Lead', {
+    refresh: function(frm) {
+        // Set query for 'item' field in the child table to show only 'Products'
+        frm.fields_dict["custom_enquiry_details"].grid.get_field("item").get_query = function() {
+            return {
+                filters: {
+                    "item_group": "Products"
+                }
+            };
+        };
+
+        // Set query for 'material' field in the child table to show only 'Raw Materials'
+        frm.fields_dict["custom_enquiry_details"].grid.get_field("material").get_query = function() {
+            return {
+                filters: {
+                    "item_group": "Raw Material"
+                }
+            };
+        };
+    }
+});
+
+

--- a/versa_system/versa_system/doctype/enqury_details/enqury_details.json
+++ b/versa_system/versa_system/doctype/enqury_details/enqury_details.json
@@ -14,7 +14,8 @@
   "size",
   "colour",
   "material",
-  "made_machinehand"
+  "made_machinehand",
+  "image"
  ],
  "fields": [
   {
@@ -80,12 +81,17 @@
    "in_list_view": 1,
    "label": "Material",
    "options": "Item"
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach Image",
+   "label": "Image"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-15 10:43:14.451031",
+ "modified": "2024-10-16 15:40:11.476842",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Enqury Details",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -8,10 +8,9 @@
  "field_order": [
   "section_break_pdm5",
   "from_lead",
-  "column_break_dtei",
-  "image",
   "section_break_xldq",
-  "lead_details"
+  "lead_details",
+  "amended_from"
  ],
  "fields": [
   {
@@ -19,20 +18,10 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "image",
-   "fieldtype": "Attach Image",
-   "label": "Image",
-   "reqd": 1
-  },
-  {
    "fieldname": "from_lead",
    "fieldtype": "Link",
    "label": "From Lead",
    "options": "Lead"
-  },
-  {
-   "fieldname": "column_break_dtei",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "section_break_xldq",
@@ -44,12 +33,23 @@
    "label": "Lead Details",
    "options": "Enqury Details",
    "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Mockup Design",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-15 11:13:00.081460",
+ "max_attachments": 10,
+ "modified": "2024-10-16 16:27:39.149720",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",


### PR DESCRIPTION
## Feature description
Need to Add a filter to separate product and Raw materials in Enquiry details child table to show items that are categorized by item group products in item field and Raw materials in Material field. And want to add multiple images in Lead and Mockup design doctype.

## Solution description
Added a filter for item doctype using set query. Added a table field image in Enquiry details table to attach multiple images. 
## Output
![image](https://github.com/user-attachments/assets/d67d3026-a436-4847-855d-ad8dfb0ccf19)
![image](https://github.com/user-attachments/assets/f3dccaa4-b7e2-42d2-838c-7f6ba5c98c13)
![image](https://github.com/user-attachments/assets/2f79e974-f19e-45a1-8d42-a1f7e95fc118)
![image](https://github.com/user-attachments/assets/17d29c13-7868-441c-a1c6-07c161640ebf)



## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Windows Edge