### PR TITLE
feat: Filter Model,Brand, Design, Size based on Item in enquiry detai…

### DIFF
--- a/versa_system/public/js/lead.js
+++ b/versa_system/public/js/lead.js
@@ -36,29 +36,41 @@ frappe.ui.form.on("Lead", {
         frm.remove_custom_button("Opportunity", "Create");
       }, 10);
     }
+
+    // Set query for 'item' field in the child table to show only 'Products'
+    frm.fields_dict["custom_enquiry_details"].grid.get_field("item").get_query =
+      function () {
+        return {
+          filters: {
+            item_group: "Products", // Adjust according to your item group
+          },
+        };
+      };
+
+    // Set query for 'material' field in the child table to show only 'Raw Materials'
+    frm.fields_dict["custom_enquiry_details"].grid.get_field(
+      "material"
+    ).get_query = function () {
+      return {
+        filters: {
+          item_group: "Raw Material",
+        },
+      };
+    };
+
+    // Set filters for multiple fields (model, brand, design, size) based on the selected 'item' in the child table 'custom_enquiry_details'
+    const fields_to_filter = ["model", "brand", "design", "size"];
+    fields_to_filter.forEach(function (field) {
+      frm.fields_dict["custom_enquiry_details"].grid.get_field(
+        field
+      ).get_query = function (doc, cdt, cdn) {
+        var child = locals[cdt][cdn]; // Get the current child row
+        return {
+          filters: {
+            item: child.item, // Filter based on the selected item in the same row
+          },
+        };
+      };
+    });
   },
 });
-
-frappe.ui.form.on('Lead', {
-    refresh: function(frm) {
-        // Set query for 'item' field in the child table to show only 'Products'
-        frm.fields_dict["custom_enquiry_details"].grid.get_field("item").get_query = function() {
-            return {
-                filters: {
-                    "item_group": "Products"
-                }
-            };
-        };
-
-        // Set query for 'material' field in the child table to show only 'Raw Materials'
-        frm.fields_dict["custom_enquiry_details"].grid.get_field("material").get_query = function() {
-            return {
-                filters: {
-                    "item_group": "Raw Material"
-                }
-            };
-        };
-    }
-});
-
-

--- a/versa_system/public/js/quotation.js
+++ b/versa_system/public/js/quotation.js
@@ -13,44 +13,6 @@ frappe.ui.form.on("Quotation", {
       add_final_design_button(frm);
     }
   },
-  from_lead: function (frm) {
-    /*
-     * Function to populate items child table on selecting Lead.
-     */
-    if (frm.doc.from_lead) {
-      frappe.call({
-        method:
-          "versa_system.versa_system.custom_scripts.quotation.py.get_lead_properties", // Ensure this path is correct
-        args: {
-          lead_name: frm.doc.from_lead,
-        },
-        callback: function (r) {
-          if (r.message) {
-            // Clear existing child table data
-            frm.clear_table("items");
-
-            // Populate child table with data from the Lead
-            r.message.forEach(function (item) {
-              var row = frm.add_child("items");
-              row.item_code = item.item_code; // Ensure these fields match your Lead's response
-
-              // Add any additional fields you want to populate
-            });
-
-            // Refresh the child table field to show updated data
-            frm.refresh_field("items");
-          } else {
-            frappe.msgprint(__("No items found for the selected Lead."));
-          }
-        },
-        error: function (err) {
-          frappe.msgprint(
-            __("Error while fetching Lead items: {0}", [err.message])
-          );
-        },
-      });
-    }
-  },
 });
 
 function add_final_design_button(frm) {

--- a/versa_system/versa_system/doctype/design/design.json
+++ b/versa_system/versa_system/doctype/design/design.json
@@ -6,7 +6,8 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "design"
+  "design",
+  "item"
  ],
  "fields": [
   {
@@ -14,11 +15,17 @@
    "fieldtype": "Data",
    "label": "Design",
    "unique": 1
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "label": "Item",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-07 15:02:04.250650",
+ "modified": "2024-10-23 09:51:30.825186",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design",

--- a/versa_system/versa_system/doctype/model/model.json
+++ b/versa_system/versa_system/doctype/model/model.json
@@ -6,19 +6,31 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "model"
+  "model",
+  "item"
  ],
  "fields": [
   {
    "fieldname": "model",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Model",
+   "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item",
+   "options": "Item",
+   "reqd": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-07 15:14:29.779739",
+ "modified": "2024-10-23 09:28:08.074836",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Model",

--- a/versa_system/versa_system/doctype/size_chart/size_chart.json
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.json
@@ -7,25 +7,27 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "section_break_fsxo",
-  "type"
+  "type",
+  "item"
  ],
  "fields": [
-  {
-   "fieldname": "section_break_fsxo",
-   "fieldtype": "Section Break"
-  },
   {
    "fieldname": "type",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Type",
    "unique": 1
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "label": "Item",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-15 11:19:41.302507",
+ "modified": "2024-10-23 09:52:25.196962",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Size Chart",


### PR DESCRIPTION
## Feature description
-Dynamic Filtering of Child Table Fields in the Lead Doctype
-The from_lead function was removed because it was not being called anywhere in the code, rendering it unnecessary and 
  unused.
## Solution description
-Implemented dynamic filters for child table fields (model, brand, design, and size) based on the selected item in the custom_enquiry_details child table
## Output
![Screenshot 2024-10-23 101114](https://github.com/user-attachments/assets/71acbf16-2fa0-4a96-82f5-01c4b7887d9c)
![Screenshot 2024-10-23 101148](https://github.com/user-attachments/assets/5d836ac7-e1c8-40e5-aba8-0b87abd72a50)

## Areas affected and ensured
-New feature in the Lead Doctype's child table functionality.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Windows Edge