### PR TITLE
feat: default delivery date in the Sales Order to be 10 days from the…

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -28,7 +28,7 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-doctype_js = {"Lead" : "public/js/lead.js","Quotation" : "public/js/quotation.js"}
+doctype_js = {"Lead" : "public/js/lead.js","Quotation" : "public/js/quotation.js","Sales Order": "public/js/sales_order.js"}
 
 
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}

--- a/versa_system/public/js/sales_order.js
+++ b/versa_system/public/js/sales_order.js
@@ -7,9 +7,9 @@ frappe.ui.form.on("Sales Order", {
       // Add 10 days to today's date
       today.setDate(today.getDate() + 10);
       // Format the date to YYYY-MM-DD
-      var defaultDate = today.toISOString().split("T")[0];
+      var default_date = today.toISOString().split("T")[0];
       // Set the default date in the delivery_date field
-      frm.set_value("delivery_date", defaultDate);
+      frm.set_value("delivery_date", default_date);
     }
   },
 });

--- a/versa_system/public/js/sales_order.js
+++ b/versa_system/public/js/sales_order.js
@@ -1,0 +1,15 @@
+frappe.ui.form.on("Sales Order", {
+  onload: function (frm) {
+    if (!frm.doc.delivery_date) {
+      // Check if delivery_date is not already set
+      // Get today's date
+      var today = new Date();
+      // Add 10 days to today's date
+      today.setDate(today.getDate() + 10);
+      // Format the date to YYYY-MM-DD
+      var defaultDate = today.toISOString().split("T")[0];
+      // Set the default date in the delivery_date field
+      frm.set_value("delivery_date", defaultDate);
+    }
+  },
+});


### PR DESCRIPTION
## Feature description
Need to set the default delivery date in the Sales Order to be 10 days from the current date.

## Solution description
Added a client-side script to the Sales Order DocType that automatically sets the delivery date to 10 days from today if it is not already specified 
## Output
![Screenshot 2024-10-23 154904](https://github.com/user-attachments/assets/17712a8e-564b-4141-a678-62b49d761297)

## Areas affected and ensured
- New feature

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
  - Windows Edge