### PR TITLE
feat: Added a color code field to color in enquiry details doctype

### DIFF
--- a/versa_system/versa_system/doctype/enqury_details/enqury_details.json
+++ b/versa_system/versa_system/doctype/enqury_details/enqury_details.json
@@ -15,7 +15,8 @@
   "colour",
   "material",
   "made_machinehand",
-  "image"
+  "image",
+  "approve"
  ],
  "fields": [
   {
@@ -73,7 +74,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Colour",
-   "options": "Colour"
+   "options": "Color"
   },
   {
    "fieldname": "material",
@@ -86,12 +87,18 @@
    "fieldname": "image",
    "fieldtype": "Attach Image",
    "label": "Image"
+  },
+  {
+   "default": "0",
+   "fieldname": "approve",
+   "fieldtype": "Check",
+   "label": "Approve"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-10-16 15:40:11.476842",
+ "modified": "2024-10-23 16:18:00.912993",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Enqury Details",


### PR DESCRIPTION
## Feature description
Need to   Add a color code field to color in enquiry details doctype

## Solution description
 Added a color code field to color in enquiry details doctype.
## Output
![image](https://github.com/user-attachments/assets/7b36ed6f-4d56-4ab2-ad93-246445a01fb0)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Windows Edge