### PR TITLE
feat: Changing status automatically

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -125,13 +125,17 @@ before_uninstall = "versa_system.setup.before_uninstall"
 # Document Events
 # ---------------
 # Hook on document methods and events
-
+# hooks.py
 doc_events = {
    "Sales Order": {
        "on_submit": "versa_system.versa_system.custom_scripts.work_order.create_work_order_from_sales_order"
    }
 }
-    
+
+
+
+
+>>>>>>> 33f425b (feat : Changing status automatically)
 # Scheduled Tasks
 # ---------------
 
@@ -249,4 +253,9 @@ fixtures = [
         ]
     }
 ]
-
+doc_events = {
+    "Lead": {
+        "before_save": "versa_system.versa_system.custom_scripts.lead.update_lead_status_on_save"
+    }
+   
+}

--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -131,11 +131,6 @@ doc_events = {
        "on_submit": "versa_system.versa_system.custom_scripts.work_order.create_work_order_from_sales_order"
    }
 }
-
-
-
-
->>>>>>> 33f425b (feat : Changing status automatically)
 # Scheduled Tasks
 # ---------------
 

--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -257,5 +257,6 @@ doc_events = {
     "Lead": {
         "before_save": "versa_system.versa_system.custom_scripts.lead.update_lead_status_on_save"
     }
+    
    
 }

--- a/versa_system/versa_system/custom_scripts/lead.py
+++ b/versa_system/versa_system/custom_scripts/lead.py
@@ -65,3 +65,8 @@ def map_lead_to_quotation(source_name, target_doc=None):
         }, target_doc, set_missing_values)
 
     return target_doc
+@frappe.whitelist()
+def update_lead_status_on_save(doc, method):
+    """Automatically change lead status to 'Interested' when saved."""
+    if doc.status == "Lead":
+        doc.status = "Interested"

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -11,3 +11,68 @@ frappe.ui.form.on('Feasibility Check', {
         }
     }
 });
+frappe.ui.form.on('Feasibility Check', {
+    after_save: function(frm) {
+        // Check if the current status is 'Lead' and update to 'Interest'
+        if (frm.doc.status === 'Lead') {
+            frm.set_value('status', 'Interest');
+            frm.save(); // Save again to persist the change
+        }
+    },
+
+    approve: function(frm) {
+        // Approve the feasibility and update lead status if linked
+        if (frm.doc.is_approved) {
+            frm.set_value('status', 'Feasibility Approved');  // Set feasibility status
+
+            if (frm.doc.from_lead) {
+                frappe.call({
+                    method: 'frappe.client.set_value',
+                    args: {
+                        doctype: 'Lead',
+                        name: frm.doc.from_lead,
+                        fieldname: 'status',
+                        value: 'Feasibility Check Approved',
+                    },
+                    callback: function(response) {
+                        if (response && !response.exc) {
+                            frappe.msgprint(
+                                `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Approved'.`,
+                                'Status Updated'
+                            );
+                        }
+                    }
+                });
+            }
+
+            frm.save(); // Save the feasibility document after approval
+        }
+    },
+
+    reject: function(frm) {
+        // Reject the feasibility and update lead status if linked
+        frm.set_value('status', 'Feasibility Rejected'); // Adjust rejection status
+
+        if (frm.doc.from_lead) {
+            frappe.call({
+                method: 'frappe.client.set_value',
+                args: {
+                    doctype: 'Lead',
+                    name: frm.doc.from_lead,
+                    fieldname: 'status',
+                    value: 'Feasibility Check Rejected', // Set lead status to rejected
+                },
+                callback: function(response) {
+                    if (response && !response.exc) {
+                        frappe.msgprint(
+                            `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Rejected'.`,
+                            'Status Updated'
+                        );
+                    }
+                }
+            });
+        }
+
+        frm.save(); // Save the document to persist the rejection
+    }
+});

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -20,13 +20,12 @@
    "fieldname": "details",
    "fieldtype": "Table",
    "label": "Details",
-   "options": "Enqury Details",
-   "read_only": 1
+   "options": "Enqury Details"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-09 09:47:47.316679",
+ "modified": "2024-10-23 16:19:10.189174",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Check",

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -3,7 +3,10 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
 class FeasibilityCheck(Document):
-    pass
+    def on_update(self):
+        """Update lead status when the feasibility check is updated."""
+        update_lead_status_on_feasibility_check(self)
+
 
 @frappe.whitelist()
 def map_feasibility_to_mockup_design(source_name, target_doc=None):
@@ -37,3 +40,37 @@ def map_feasibility_to_mockup_design(source_name, target_doc=None):
         }, target_doc, set_missing_values)
 
     return target_doc
+    
+import frappe
+from frappe.model.document import Document
+
+class FeasibilityCheck(Document):
+    def on_update(self):
+        # Call the update lead status function when the document is updated
+        update_lead_status_on_feasibility_check(self)
+
+def update_lead_status_on_feasibility_check(doc):
+    """Update the status of the associated lead when the feasibility check is approved or rejected."""
+    if doc.from_lead:
+        try:
+            # Fetch the linked lead document
+            lead = frappe.get_doc("Lead", doc.from_lead)
+            
+            # Update status based on workflow state
+            if doc.workflow_state == "Approved":
+                lead.status = "Feasibility Check Approved"
+            elif doc.workflow_state == "Rejected":
+                lead.status = "Feasibility Check Rejected"
+            
+            lead.save()
+
+            # Display success message
+            frappe.msgprint(
+                f"Lead {lead.name} status updated to '{lead.status}'.",
+                alert=True
+            )
+        except frappe.DoesNotExistError:
+            frappe.throw(f"The lead {doc.from_lead} does not exist.")
+        except Exception as e:
+            frappe.log_error(f"Failed to update lead status: {str(e)}")
+            frappe.throw("An error occurred while updating the lead status.")

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -12,3 +12,74 @@ frappe.ui.form.on('Mockup Design', {
         }
     }
 });
+frappe.ui.form.on('Mockup Design', {
+    after_save: function(frm) {
+        // Check if the current status is 'Lead' and update it to 'Feasibility Approved'
+        if (frm.doc.status === 'Lead') {
+            frm.set_value('status', 'Mockup Design Approved');
+            frm.save(); // Save again to persist the change
+        }
+    },
+
+    approve: function(frm) {
+        // Approve the mockup design and update lead status if linked
+        if (frm.doc.is_approved) {
+            frm.set_value('status', 'Mockup Design Approved');  // Set mockup design status
+
+            // Update the linked lead's status if applicable
+            if (frm.doc.from_lead) {
+                frappe.call({
+                    method: 'frappe.client.set_value',
+                    args: {
+                        doctype: 'Lead',
+                        name: frm.doc.from_lead,
+                        fieldname: 'status',
+                        value: 'Mockup Design Approved',
+                    },
+                    callback: function(response) {
+                        if (response && !response.exc) {
+                            frappe.msgprint(
+                                `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Approved'.`,
+                                'Status Updated'
+                            );
+                        } else {
+                            frappe.msgprint('Failed to update lead status.', 'Error');
+                        }
+                    }
+                });
+            }
+
+            frm.save(); // Save the mockup design document after approval
+        }
+    },
+
+    reject: function(frm) {
+        // Reject the mockup design and update lead status if linked
+        frm.set_value('status', 'Mockup Design Rejected'); // Set mockup design rejection status
+
+        // Update the linked lead's status if applicable
+        if (frm.doc.from_lead) {
+            frappe.call({
+                method: 'frappe.client.set_value',
+                args: {
+                    doctype: 'Lead',
+                    name: frm.doc.from_lead,
+                    fieldname: 'status',
+                    value: 'Mockup Design Rejected', // Set lead status to rejected
+                },
+                callback: function(response) {
+                    if (response && !response.exc) {
+                        frappe.msgprint(
+                            `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Rejected'.`,
+                            'Status Updated'
+                        );
+                    } else {
+                        frappe.msgprint('Failed to update lead status.', 'Error');
+                    }
+                }
+            });
+        }
+
+        frm.save(); // Save the document to persist the rejection
+    }
+});

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -27,3 +27,37 @@ def map_mockup_design_to_quotation(source_name, target_doc=None):
         }, target_doc, set_missing_values)
 
     return target_doc
+import frappe
+from frappe.model.document import Document
+
+class MockupDesign(Document):
+    def on_update(self):
+        # Call the function to update lead status when the document is updated
+        update_lead_status_on_mockup_design(self)
+
+def update_lead_status_on_mockup_design(doc):
+    """Update the status of the associated lead when the mockup design is approved or rejected."""
+    if doc.from_lead:
+        try:
+            # Fetch the linked lead document
+            lead = frappe.get_doc("Lead", doc.from_lead)
+            
+            # Update status based on workflow state
+            if doc.workflow_state == "Approved":
+                lead.status = "Mockup Design Approved"
+            elif doc.workflow_state == "Rejected":
+                lead.status = "Mockup Design Rejected"
+            
+            lead.save()
+
+            # Display success message
+            frappe.msgprint(
+                f"Lead {lead.name} status updated to '{lead.status}'.",
+                alert=True
+            )
+        except frappe.DoesNotExistError:
+            frappe.throw(f"The lead {doc.from_lead} does not exist.")
+        except Exception as e:
+            # Log the error for debugging purposes
+            frappe.log_error(f"Failed to update lead status: {str(e)}")
+            frappe.throw("An error occurred while updating the lead status.")


### PR DESCRIPTION
## Feature description
Need to Change status automatically

## Solution description
Changing status automatically on Lead doctype.
* When Lead is saved, the status will change to Interested.
* When Feasibility check is approved, status will change to Feasibility check approved.
* When Feasibility check is Rejected, status will change to Feasibility check Rejected.
* When Mockup design is Approved, status will change to Mockup design is Approved.
* When Mockup design is Rejected, status will change to Mockup design is Rejected.

## Output
![image](https://github.com/user-attachments/assets/0ec020a2-9053-4f44-8aeb-4e2169f66e6e)
![image](https://github.com/user-attachments/assets/55e0186d-687a-4412-8489-4dfdff21e289)
![image](https://github.com/user-attachments/assets/49e8ff26-266c-4f6a-9d54-294f038a61fa)
![image](https://github.com/user-attachments/assets/f20ed956-fd59-4a6c-9151-20bf752ac6f6)
![image](https://github.com/user-attachments/assets/758ec544-abad-4a03-adb6-6a002fea5765)
![image](https://github.com/user-attachments/assets/2475807e-1143-4402-9bb0-164ae8aa9383)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Windows Edge