### PR TITLE
feat: Add Comment box

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -1,79 +1,80 @@
-frappe.ui.form.on('Feasibility Check', {
-    refresh: function(frm) {
-        // Check if the Feasibility Check is not new and is approved
-        if (frm.doc.workflow_state === 'Approved') {
-            frm.add_custom_button(__('Mockup Design'), function() {
-                frappe.model.open_mapped_doc({
-                    method: 'versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_feasibility_to_mockup_design',
-                    frm: frm
-                });
-            }, __('Create'));
-        }
+frappe.ui.form.on("Feasibility Check", {
+  refresh: function (frm) {
+    // Check if the Feasibility Check is not new and is approved
+    if (frm.doc.workflow_state === "Approved") {
+      frm.add_custom_button(__("Mockup Design"), function () {
+        frappe.model.open_mapped_doc({
+          method:
+            "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_feasibility_to_mockup_design",
+          frm: frm,
+        });
+      });
     }
+  },
 });
 
-frappe.ui.form.on('Feasibility Check', {
-    after_save: function(frm) {
-        // Check if the current status is 'Lead' and update to 'Interest'
-        if (frm.doc.status === 'Lead') {
-            frm.set_value('status', 'Interest');
-            frm.save(); // Save again to persist the change
-        }
-    },
-
-    approve: function(frm) {
-        // Approve the feasibility and update lead status if linked
-        if (frm.doc.is_approved) {
-            frm.set_value('status', 'Feasibility Approved');  // Set feasibility status
-
-            if (frm.doc.from_lead) {
-                frappe.call({
-                    method: 'frappe.client.set_value',
-                    args: {
-                        doctype: 'Lead',
-                        name: frm.doc.from_lead,
-                        fieldname: 'status',
-                        value: 'Feasibility Check Approved',
-                    },
-                    callback: function(response) {
-                        if (response && !response.exc) {
-                            frappe.msgprint(
-                                `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Approved'.`,
-                                'Status Updated'
-                            );
-                        }
-                    }
-                });
-            }
-
-            frm.save(); // Save the feasibility document after approval
-        }
-    },
-
-    reject: function(frm) {
-        // Reject the feasibility and update lead status if linked
-        frm.set_value('status', 'Feasibility Rejected'); // Adjust rejection status
-
-        if (frm.doc.from_lead) {
-            frappe.call({
-                method: 'frappe.client.set_value',
-                args: {
-                    doctype: 'Lead',
-                    name: frm.doc.from_lead,
-                    fieldname: 'status',
-                    value: 'Feasibility Check Rejected', // Set lead status to rejected
-                },
-                callback: function(response) {
-                    if (response && !response.exc) {
-                        frappe.msgprint(
-                            `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Rejected'.`,
-                            'Status Updated'
-                        );
-                    }
-                }
-            });
-        }
-
-        frm.save(); // Save the document to persist the rejection
+frappe.ui.form.on("Feasibility Check", {
+  after_save: function (frm) {
+    // Check if the current status is 'Lead' and update to 'Interest'
+    if (frm.doc.status === "Lead") {
+      frm.set_value("status", "Interest");
+      frm.save(); // Save again to persist the change
     }
+  },
+
+  approve: function (frm) {
+    // Approve the feasibility and update lead status if linked
+    if (frm.doc.is_approved) {
+      frm.set_value("status", "Feasibility Approved"); // Set feasibility status
+
+      if (frm.doc.from_lead) {
+        frappe.call({
+          method: "frappe.client.set_value",
+          args: {
+            doctype: "Lead",
+            name: frm.doc.from_lead,
+            fieldname: "status",
+            value: "Feasibility Check Approved",
+          },
+          callback: function (response) {
+            if (response && !response.exc) {
+              frappe.msgprint(
+                `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Approved'.`,
+                "Status Updated"
+              );
+            }
+          },
+        });
+      }
+
+      frm.save(); // Save the feasibility document after approval
+    }
+  },
+
+  reject: function (frm) {
+    // Reject the feasibility and update lead status if linked
+    frm.set_value("status", "Feasibility Rejected"); // Adjust rejection status
+
+    if (frm.doc.from_lead) {
+      frappe.call({
+        method: "frappe.client.set_value",
+        args: {
+          doctype: "Lead",
+          name: frm.doc.from_lead,
+          fieldname: "status",
+          value: "Feasibility Check Rejected", // Set lead status to rejected
+        },
+        callback: function (response) {
+          if (response && !response.exc) {
+            frappe.msgprint(
+              `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Rejected'.`,
+              "Status Updated"
+            );
+          }
+        },
+      });
+    }
+
+    frm.save(); // Save the document to persist the rejection
+  },
 });

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -1,49 +1,57 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "FC.#####",
-  "creation": "2024-09-13 11:12:54.710909",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": ["from_lead", "details"],
-  "fields": [
-    {
-      "fieldname": "from_lead",
-      "fieldtype": "Link",
-      "label": "From Lead",
-      "options": "Lead"
-    },
-    {
-      "fieldname": "details",
-      "fieldtype": "Table",
-      "label": "Details",
-      "options": "Enqury Details"
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "links": [],
-
-  "modified": "2024-10-30 11:21:59.379276",
-  "modified_by": "Administrator",
-  "module": "Versa System",
-  "name": "Feasibility Check",
-  "naming_rule": "Expression (old style)",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": []
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "FC.#####",
+ "creation": "2024-09-13 11:12:54.710909",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "from_lead",
+  "details",
+  "comment"
+ ],
+ "fields": [
+  {
+   "fieldname": "from_lead",
+   "fieldtype": "Link",
+   "label": "From Lead",
+   "options": "Lead"
+  },
+  {
+   "fieldname": "details",
+   "fieldtype": "Table",
+   "label": "Details",
+   "options": "Enqury Details"
+  },
+  {
+   "fieldname": "comment",
+   "fieldtype": "Text",
+   "label": "Comment"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-11-04 10:19:33.322068",
+ "modified_by": "Administrator",
+ "module": "Versa System",
+ "name": "Feasibility Check",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -1,85 +1,86 @@
-frappe.ui.form.on('Mockup Design', {
-    refresh: function(frm) {
-        // Check if the workflow state is "Approved"
-        if (frm.doc.workflow_state === 'Approved') {
-            frm.add_custom_button(__('Quotation'), function() {
-                // Call the mapping function for Mockup Design to Quotation
-                frappe.model.open_mapped_doc({
-                    method: 'versa_system.versa_system.doctype.mockup_design.mockup_design.map_mockup_design_to_quotation',
-                    frm: frm
-                });
-            }, __('Create'));
-        }
+frappe.ui.form.on("Mockup Design", {
+  refresh: function (frm) {
+    // Check if the workflow state is "Approved"
+    if (frm.doc.workflow_state === "Approved") {
+      frm.add_custom_button(__("Quotation"), function () {
+        // Call the mapping function for Mockup Design to Quotation
+        frappe.model.open_mapped_doc({
+          method:
+            "versa_system.versa_system.doctype.mockup_design.mockup_design.map_mockup_design_to_quotation",
+          frm: frm,
+        });
+      });
     }
+  },
 });
-frappe.ui.form.on('Mockup Design', {
-    after_save: function(frm) {
-        // Check if the current status is 'Lead' and update it to 'Feasibility Approved'
-        if (frm.doc.status === 'Lead') {
-            frm.set_value('status', 'Mockup Design Approved');
-            frm.save(); // Save again to persist the change
-        }
-    },
-
-    approve: function(frm) {
-        // Approve the mockup design and update lead status if linked
-        if (frm.doc.is_approved) {
-            frm.set_value('status', 'Mockup Design Approved');  // Set mockup design status
-
-            // Update the linked lead's status if applicable
-            if (frm.doc.from_lead) {
-                frappe.call({
-                    method: 'frappe.client.set_value',
-                    args: {
-                        doctype: 'Lead',
-                        name: frm.doc.from_lead,
-                        fieldname: 'status',
-                        value: 'Mockup Design Approved',
-                    },
-                    callback: function(response) {
-                        if (response && !response.exc) {
-                            frappe.msgprint(
-                                `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Approved'.`,
-                                'Status Updated'
-                            );
-                        } else {
-                            frappe.msgprint('Failed to update lead status.', 'Error');
-                        }
-                    }
-                });
-            }
-
-            frm.save(); // Save the mockup design document after approval
-        }
-    },
-
-    reject: function(frm) {
-        // Reject the mockup design and update lead status if linked
-        frm.set_value('status', 'Mockup Design Rejected'); // Set mockup design rejection status
-
-        // Update the linked lead's status if applicable
-        if (frm.doc.from_lead) {
-            frappe.call({
-                method: 'frappe.client.set_value',
-                args: {
-                    doctype: 'Lead',
-                    name: frm.doc.from_lead,
-                    fieldname: 'status',
-                    value: 'Mockup Design Rejected', // Set lead status to rejected
-                },
-                callback: function(response) {
-                    if (response && !response.exc) {
-                        frappe.msgprint(
-                            `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Rejected'.`,
-                            'Status Updated'
-                        );
-                    } else {
-                        frappe.msgprint('Failed to update lead status.', 'Error');
-                    }
-                }
-            });
-        }
-
-        frm.save(); // Save the document to persist the rejection
+frappe.ui.form.on("Mockup Design", {
+  after_save: function (frm) {
+    // Check if the current status is 'Lead' and update it to 'Feasibility Approved'
+    if (frm.doc.status === "Lead") {
+      frm.set_value("status", "Mockup Design Approved");
+      frm.save(); // Save again to persist the change
     }
+  },
+
+  approve: function (frm) {
+    // Approve the mockup design and update lead status if linked
+    if (frm.doc.is_approved) {
+      frm.set_value("status", "Mockup Design Approved"); // Set mockup design status
+
+      // Update the linked lead's status if applicable
+      if (frm.doc.from_lead) {
+        frappe.call({
+          method: "frappe.client.set_value",
+          args: {
+            doctype: "Lead",
+            name: frm.doc.from_lead,
+            fieldname: "status",
+            value: "Mockup Design Approved",
+          },
+          callback: function (response) {
+            if (response && !response.exc) {
+              frappe.msgprint(
+                `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Approved'.`,
+                "Status Updated"
+              );
+            } else {
+              frappe.msgprint("Failed to update lead status.", "Error");
+            }
+          },
+        });
+      }
+
+      frm.save(); // Save the mockup design document after approval
+    }
+  },
+
+  reject: function (frm) {
+    // Reject the mockup design and update lead status if linked
+    frm.set_value("status", "Mockup Design Rejected"); // Set mockup design rejection status
+
+    // Update the linked lead's status if applicable
+    if (frm.doc.from_lead) {
+      frappe.call({
+        method: "frappe.client.set_value",
+        args: {
+          doctype: "Lead",
+          name: frm.doc.from_lead,
+          fieldname: "status",
+          value: "Mockup Design Rejected", // Set lead status to rejected
+        },
+        callback: function (response) {
+          if (response && !response.exc) {
+            frappe.msgprint(
+              `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Rejected'.`,
+              "Status Updated"
+            );
+          } else {
+            frappe.msgprint("Failed to update lead status.", "Error");
+          }
+        },
+      });
+    }
+
+    frm.save(); // Save the document to persist the rejection
+  },
 });


### PR DESCRIPTION
## Feature description
Need a comment box in the feasibility check and to remove the create button in the feasibility check & mockup design
## Solution description
- Created comment box in the feasibility 
- remove the create button in feasibility check & mockup design  and replace with  corresponding button
## Output
![Screenshot 2024-11-04 104127](https://github.com/user-attachments/assets/9999d8e4-c6f3-4693-aa31-3d60fe957147)
![Screenshot 2024-11-04 104143](https://github.com/user-attachments/assets/bdb3a428-8ba5-404a-9041-c9e248f3bfa7)

## Areas affected and ensured
- New feature

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
  - Windows Edge