### PR TITLE
feat: Add function to update Lead details from Feasibility Check

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -130,9 +130,6 @@ doc_events = {
    "Sales Order": {
        "on_submit": "versa_system.versa_system.custom_scripts.work_order.create_work_order_from_sales_order"
    },
-   "Feasibility Check": {
-        "on_update": "versa_system.versa_system.custom_scripts.fesibility.update_lead_from_feasibility_check"
-    }
 }
 # Scheduled Tasks
 # ---------------

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -1,79 +1,138 @@
-frappe.ui.form.on('Feasibility Check', {
-    refresh: function(frm) {
-        // Check if the Feasibility Check is not new and is approved
-        if (frm.doc.workflow_state === 'Approved') {
-            frm.add_custom_button(__('Mockup Design'), function() {
-                frappe.model.open_mapped_doc({
-                    method: 'versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_feasibility_to_mockup_design',
-                    frm: frm
-                });
-            }, __('Create'));
-        }
+frappe.ui.form.on("Feasibility Check", {
+  refresh: function (frm) {
+    // Check if the Feasibility Check is not new and is approved
+    if (frm.doc.workflow_state === "Approved") {
+      frm.add_custom_button(__("Mockup Design"), function () {
+        frappe.model.open_mapped_doc({
+          method:
+            "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_feasibility_to_mockup_design",
+          frm: frm,
+        });
+      });
+
+      // Call the function to update the Lead and add the navigation button
+      updateAndNavigateToLead(frm);
     }
-});
+  },
 
-frappe.ui.form.on('Feasibility Check', {
-    after_save: function(frm) {
-        // Check if the current status is 'Lead' and update to 'Interest'
-        if (frm.doc.status === 'Lead') {
-            frm.set_value('status', 'Interest');
-            frm.save(); // Save again to persist the change
-        }
-    },
+  after_save: function (frm) {
+    // Check if the current status is 'Lead' and update to 'Interest'
+    if (frm.doc.status === "Lead") {
+      frm.set_value("status", "Interest");
+      frm.save(); // Save again to persist the change
+    }
+  },
 
-    approve: function(frm) {
-        // Approve the feasibility and update lead status if linked
-        if (frm.doc.is_approved) {
-            frm.set_value('status', 'Feasibility Approved');  // Set feasibility status
+  approve: function (frm) {
+    // Approve the feasibility and update lead status if linked
+    if (frm.doc.is_approved) {
+      frm.set_value("status", "Feasibility Approved"); // Set feasibility status
 
-            if (frm.doc.from_lead) {
-                frappe.call({
-                    method: 'frappe.client.set_value',
-                    args: {
-                        doctype: 'Lead',
-                        name: frm.doc.from_lead,
-                        fieldname: 'status',
-                        value: 'Feasibility Check Approved',
-                    },
-                    callback: function(response) {
-                        if (response && !response.exc) {
-                            frappe.msgprint(
-                                `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Approved'.`,
-                                'Status Updated'
-                            );
-                        }
-                    }
-                });
+      if (frm.doc.from_lead) {
+        frappe.call({
+          method: "frappe.client.set_value",
+          args: {
+            doctype: "Lead",
+            name: frm.doc.from_lead,
+            fieldname: "status",
+            value: "Feasibility Check Approved",
+          },
+          callback: function (response) {
+            if (response && !response.exc) {
+              frappe.msgprint(
+                `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Approved'.`,
+                "Status Updated"
+              );
+            } else {
+              frappe.msgprint(__("Failed to update Lead status."));
             }
+          },
+        });
+      }
 
-            frm.save(); // Save the feasibility document after approval
-        }
-    },
-
-    reject: function(frm) {
-        // Reject the feasibility and update lead status if linked
-        frm.set_value('status', 'Feasibility Rejected'); // Adjust rejection status
-
-        if (frm.doc.from_lead) {
-            frappe.call({
-                method: 'frappe.client.set_value',
-                args: {
-                    doctype: 'Lead',
-                    name: frm.doc.from_lead,
-                    fieldname: 'status',
-                    value: 'Feasibility Check Rejected', // Set lead status to rejected
-                },
-                callback: function(response) {
-                    if (response && !response.exc) {
-                        frappe.msgprint(
-                            `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Rejected'.`,
-                            'Status Updated'
-                        );
-                    }
-                }
-            });
-        }
-
-        frm.save(); // Save the document to persist the rejection
+      frm.save(); // Save the feasibility document after approval
     }
+  },
+
+  reject: function (frm) {
+    // Reject the feasibility and update lead status if linked
+    frm.set_value("status", "Feasibility Rejected"); // Adjust rejection status
+
+    if (frm.doc.from_lead) {
+      frappe.call({
+        method: "frappe.client.set_value",
+        args: {
+          doctype: "Lead",
+          name: frm.doc.from_lead,
+          fieldname: "status",
+          value: "Feasibility Check Rejected", // Set lead status to rejected
+        },
+        callback: function (response) {
+          if (response && !response.exc) {
+            frappe.msgprint(
+              `Lead ${frm.doc.from_lead} status updated to 'Feasibility Check Rejected'.`,
+              "Status Updated"
+            );
+          } else {
+            frappe.msgprint(__("Failed to update Lead status."));
+          }
+        },
+      });
+    }
+
+    frm.save(); // Save the document to persist the rejection
+  },
 });
+
+// Function to update the Lead with table data from Feasibility Check
+function update_lead_from_feasibility_check(frm) {
+  const details = frm.doc.details.map((row) => ({
+    item: row.item,
+    brand: row.brand,
+    rate_range: row.rate_range,
+    design: row.design,
+    model: row.model,
+    approve: row.approve,
+  }));
+
+  let messageDisplayed = false;
+
+  frappe.call({
+    method: "versa_system.versa_system.custom_scripts.fesibility.update_lead",
+    args: {
+      lead_name: frm.doc.from_lead,
+      details: JSON.stringify(details), // Ensure details are sent as JSON string
+    },
+    callback: function (response) {
+      if (response.message && !messageDisplayed) {
+        frappe.msgprint(__("Lead updated successfully."));
+        messageDisplayed = true; // Set flag to true after displaying the message
+      } else if (!response.message && !messageDisplayed) {
+        frappe.msgprint(__("Error occurred while updating the Lead."));
+        messageDisplayed = true;
+      }
+    },
+    error: function (error) {
+      if (!messageDisplayed) {
+        frappe.msgprint(
+          __("Error occurred while updating the Lead: ") + error.message
+        );
+        messageDisplayed = true;
+      }
+    },
+  });
+}
+
+// Function to update the Lead and navigate to it
+function updateAndNavigateToLead(frm) {
+  update_lead_from_feasibility_check(frm);
+
+  // Add a button to navigate to the Lead
+  frm.add_custom_button(__("Go to Lead"), function () {
+    if (!frm.doc.from_lead) {
+      frappe.msgprint(__("Please select a Lead before proceeding."));
+      return;
+    }
+    frappe.set_route("Form", "Lead", frm.doc.from_lead);
+  });
+}


### PR DESCRIPTION
## Feature description
Lead Update from Feasibility Check and Navigation Buttons

## Solution description
- Lead Update: When a Feasibility Check is approved or rejected, the lead's status is updated, and the associated details from 
  the Feasibility Check are passed to the Lead document. This includes updating a child table in the Lead with the relevant data 
  from the Feasibility Check.
- "Go to Lead": This button navigates to the associated Lead document from the Feasibility Check.
## Output
![Screenshot 2024-11-06 101417](https://github.com/user-attachments/assets/1a7c3e29-7e6f-43d4-b7d0-f1f0541f1fd1)
![Screenshot 2024-11-06 101431](https://github.com/user-attachments/assets/556bbe1c-d4b5-4120-90da-7e1ee65923ee)
![Screenshot 2024-11-06 101502](https://github.com/user-attachments/assets/ef29004c-2d07-4d86-bedb-642442afc44a)

## Areas affected and ensured
- Feasibility Check DocType: Updates to the Feasibility Check workflow, including the addition of custom buttons for navigating 
  between the Lead and Feasibility Check forms.
- Lead DocType: The lead  child table data are updated based on the information provided in the Feasibility Check
## Is there any existing behavior change of other features due to this code change?
- Child Table Update: The child table in the Lead DocType is updated with new details from the Feasibility Check.
- Navigation Behavior: New custom buttons for navigation (e.g., "Go to Lead" ) have been introduced

## Was this feature tested on the browsers?
 - Windows Edge