### PR TITLE
Added the quotation custom field 

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -130,6 +130,10 @@ doc_events = {
    "Sales Order": {
        "on_submit": "versa_system.versa_system.custom_scripts.work_order.create_work_order_from_sales_order"
    },
+   "Final Design": {
+        "on_submit": "versa_system.versa_system.custom_scripts.quotation.update_quotation_final_design_status",
+        "on_update": "versa_system.versa_system.custom_scripts.quotation.update_quotation_final_design_status"
+    }
 }
 # Scheduled Tasks
 # ---------------
@@ -252,5 +256,5 @@ doc_events = {
     "Lead": {
         "before_save": "versa_system.versa_system.custom_scripts.lead.update_lead_status_on_save"
     }
-   
+
 }

--- a/versa_system/setup.py
+++ b/versa_system/setup.py
@@ -4,6 +4,8 @@ from frappe import _
 
 def after_install():
     create_custom_fields(get_brand_custom_fields(), ignore_validate=True)
+    create_custom_fields(get_quotation_custom_fields(), ignore_validate=True)
+
 
 
 def after_migrate():
@@ -11,13 +13,15 @@ def after_migrate():
 
 def before_uninstall():
     delete_custom_fields(get_brand_custom_fields())
-    
+    delete_custom_fields(get_quotation_custom_fields())
+
+
 def delete_custom_fields(custom_fields: dict):
     """
     Method to delete custom fields from doctypes.
-    
+
     Args:
-        custom_fields (dict): Dictionary of custom fields with the format 
+        custom_fields (dict): Dictionary of custom fields with the format
                               {'Doctype': [{'fieldname': 'your_fieldname', ...}]}
     """
     for doctype, fields in custom_fields.items():
@@ -30,7 +34,7 @@ def delete_custom_fields(custom_fields: dict):
 def get_brand_custom_fields():
     """
     Define custom fields for the Brand doctype.
-    
+
     Returns:
         dict: Custom field definitions for the Brand doctype.
     """
@@ -43,6 +47,24 @@ def get_brand_custom_fields():
                 "options": "Item",  # Link to the Item doctype
                 "insert_after": "brand",  # Field location (insert after Brand field)
                 "reqd": 1  # Mark the field as mandatory (1 = True, 0 = False)
+            }
+        ]
+    }
+def get_quotation_custom_fields():
+    """
+    Define custom fields for the Quotation doctype.
+
+    Returns:
+        dict: Custom field definitions for the Quotation doctype.
+    """
+    return {
+        "Quotation": [
+            {
+                "fieldname": "final_design_approval",
+                "fieldtype": "Data",
+                "label": "Final Design Approval",
+                "insert_after": "order_type",  
+                "reqd": 1
             }
         ]
     }


### PR DESCRIPTION
## Feature description
Need to Create Quotation Custom Field "Final Design Approval" using Setup.py

## Solution description
Created Quotation Custom Field "Final Design Approval"   using Setup.py

## Output
![image](https://github.com/user-attachments/assets/e653a567-abc5-4fa4-b8c7-bfae3dfba8e0)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox