### PR TITLE
Fixed the import error in Mockup Design Doctype

### DIFF
--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -3,6 +3,7 @@
 import frappe
 import frappe
 from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
 
 class MockupDesign(Document):
     def on_update(self):
@@ -16,13 +17,13 @@ def update_lead_status_on_mockup_design(doc):
         try:
             # Fetch the linked lead document
             lead = frappe.get_doc("Lead", doc.from_lead)
-            
+
             # Update status based on workflow state
             if doc.workflow_state == "Approved":
                 lead.status = "Mockup Design Approved"
             elif doc.workflow_state == "Rejected":
                 lead.status = "Mockup Design Rejected"
-            
+
             lead.save()
 
             # Display success message


### PR DESCRIPTION
## Feature description
Need to Fix the import error "from frappe.model.mapper import get_mapped_doc" in Mockup Design Doctype 

## Solution description
 Fixed the import error "from frappe.model.mapper import get_mapped_doc" in Mockup Design Doctype while mapping Mockup Design Doctype to Quotation Doctype
## Output
![image](https://github.com/user-attachments/assets/d94a0d3e-468f-4257-b64f-5c3ed3976775)
## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox