### PR TITLE
Hide the Create button if the Quotation is not approved in Quotation Doctype

### DIFF
--- a/versa_system/public/js/quotation.js
+++ b/versa_system/public/js/quotation.js
@@ -8,7 +8,10 @@ frappe.ui.form.on("Quotation", {
             // Check Final Design status after some delay
             setTimeout(function() {
                 check_final_design_status_and_update_buttons(frm);
-            }, 10); // Adjust the timeout as needed
+            }, 100); // Adjust the timeout as needed
+        }else {
+            // Hide the "Create" button if the Quotation is not approved
+            frm.page.hide_menu_item("Create");
         }
     },
 });


### PR DESCRIPTION
## Feature description
Need to:Hide the Create button if the Quotation is not approved in Quotation Doctype

## Solution description
Hide the Create button if the Quotation is not approved in Quotation Doctype
## Output
![image](https://github.com/user-attachments/assets/5d7384d9-4192-4d02-89a5-9cf7b1436e7d)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox