### PR TITLE
Created Go to Lead Custom Button in Mockup Design Doctype

### DIFF
--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -2,6 +2,9 @@ frappe.ui.form.on('Mockup Design', {
     refresh: function(frm) {
         // Check if the workflow state is "Approved"
         if (frm.doc.workflow_state === 'Approved') {
+          frm.add_custom_button(__("Go to Lead"), function () {
+            frappe.set_route("Form", "Lead", frm.doc.from_lead);
+          });
             frm.add_custom_button(__('Quotation'), function() {
                 // Call the mapping function for Mockup Design to Quotation
                 frappe.model.open_mapped_doc({


### PR DESCRIPTION
## Feature description
Need to Create Go to Lead Custom Button in Mockup Design Doctype.

## Solution description
After mockup design approval Created "Go to Lead" Custom Button  in Mockup Design Doctype.
## Output
![image](https://github.com/user-attachments/assets/08f793aa-636a-4b83-8309-af3c1edd09d5)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox