### PR TITLE
fix: Removed some options

### DIFF
--- a/versa_system/setup.py
+++ b/versa_system/setup.py
@@ -123,7 +123,7 @@ def get_property_setters():
             "doc_type": "Lead",
             "field_name": "status",
             "property": "options",
-            "value": "Lead\n Open\nOpportunity\nQuotation\nLost Quotation\nInterested\nFeasibility Check Approved\nConverted\nFeasibility Check Rejected\nMockup Design Approved\nMockup Design Rejected\nOn Review\nQuotation Rejected"
+            "value": "Lead\n Open\nQuotation\nLost Quotation\nInterested\nFeasibility Check Approved\nConverted\nFeasibility Check Rejected\nMockup Design Approved\nMockup Design Rejected\nOn Review\nQuotation Rejected"
         },
        
     ]


### PR DESCRIPTION
## Feature description
Need to  Remove some options in the status field of Lead doctype.
## Solution description
 Removed some options due to it is too long .
## Output
![image](https://github.com/user-attachments/assets/f55b32d0-cd69-4b75-ad52-53bbc6d10f9b)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Windows Edge