### PR TITLE
Fix the Go to Lead button in Mockup Design Doctype

### DIFF
--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -1,12 +1,16 @@
 frappe.ui.form.on('Mockup Design', {
-    refresh: function(frm) {
+    refresh: function (frm) {
+        // Ensure the form is saved before adding buttons
+        if (!frm.is_new()){
+            // Add a custom button to navigate to the linked Lead
+            frm.add_custom_button(__("Go to Lead"), function () {
+                frappe.set_route("Form", "Lead", frm.doc.from_lead);
+            });
+        }
+
         // Check if the workflow state is "Approved"
         if (frm.doc.workflow_state === 'Approved') {
-          frm.add_custom_button(__("Go to Lead"), function () {
-            frappe.set_route("Form", "Lead", frm.doc.from_lead);
-          });
-            frm.add_custom_button(__('Quotation'), function() {
-                // Call the mapping function for Mockup Design to Quotation
+            frm.add_custom_button(__('Quotation'), function () {
                 frappe.model.open_mapped_doc({
                     method: 'versa_system.versa_system.doctype.mockup_design.mockup_design.map_mockup_design_to_quotation',
                     frm: frm
@@ -14,6 +18,7 @@ frappe.ui.form.on('Mockup Design', {
             }, __('Create'));
         }
     },
+
 
     after_save: function(frm) {
         // Check if the current status is 'Feasibility Check Approved' and update it to 'opportunity'


### PR DESCRIPTION
## Feature description
Need to: Fix the Go to Lead button in Mockup Design Doctype

## Solution description
Fixed the Go to Lead button in Mockup Design Doctype when the Mockup Design is saved 
## Output
![image](https://github.com/user-attachments/assets/547209c3-d779-4135-9821-804ce3dcff09)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox