### PR TITLE
feat: Made image mandatory and required at least one approval in Lead

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -1,58 +1,54 @@
 {
- "actions": [],
- "allow_rename": 1,
- "autoname": "FC.#####",
- "creation": "2024-09-13 11:12:54.710909",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "from_lead",
-  "select_all",
-  "details"
- ],
- "fields": [
-  {
-   "fieldname": "from_lead",
-   "fieldtype": "Link",
-   "label": "From Lead",
-   "options": "Lead"
-  },
-  {
-   "fieldname": "details",
-   "fieldtype": "Table",
-   "label": "Details",
-   "options": "Enqury Details"
-  },
-  {
-   "default": "0",
-   "fieldname": "select_all",
-   "fieldtype": "Check",
-   "label": "Select All"
-  }
- ],
- "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2024-11-18 16:58:18.311136",
- "modified_by": "Administrator",
- "module": "Versa System",
- "name": "Feasibility Check",
- "naming_rule": "Expression (old style)",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+  "actions": [],
+  "allow_rename": 1,
+  "autoname": "FC.#####",
+  "creation": "2024-09-13 11:12:54.710909",
+  "doctype": "DocType",
+  "engine": "InnoDB",
+  "field_order": ["from_lead", "select_all", "details"],
+  "fields": [
+    {
+      "fieldname": "from_lead",
+      "fieldtype": "Link",
+      "label": "From Lead",
+      "options": "Lead"
+    },
+    {
+      "fieldname": "details",
+      "fieldtype": "Table",
+      "label": "Details",
+      "options": "Enqury Details"
+    },
+    {
+      "default": "0",
+      "fieldname": "select_all",
+      "fieldtype": "Check",
+      "label": "Select All"
+    }
+  ],
+  "index_web_pages_for_search": 1,
+  "links": [],
+  "modified": "2024-11-18 16:58:18.311136",
+  "modified_by": "Administrator",
+  "module": "Versa System",
+  "name": "Feasibility Check",
+  "naming_rule": "Expression (old style)",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    }
+  ],
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": []
 }

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.json
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.json
@@ -10,6 +10,7 @@
   "from_lead",
   "section_break_xldq",
   "lead_details",
+  "previous_details",
   "amended_from"
  ],
  "fields": [
@@ -34,6 +35,12 @@
    "options": "Enqury Details"
   },
   {
+   "fieldname": "previous_details",
+   "fieldtype": "Table",
+   "label": "Previous Details",
+   "options": "Mockup Details"
+  },
+  {
    "fieldname": "amended_from",
    "fieldtype": "Link",
    "label": "Amended From",
@@ -48,7 +55,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 10,
- "modified": "2024-10-29 10:12:06.312968",
+ "modified": "2024-11-19 12:51:39.712283",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Mockup Design",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -1,15 +1,21 @@
-# Copyright (c) 2024, efeone and contributors
-# For license information, please see license.txt
-import frappe
 import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
 class MockupDesign(Document):
+    def validate(self):
+        # Ensure each row in lead_details table has an image
+        self.check_image_field_in_lead_details()
+
     def on_update(self):
         # Call the function to update lead status when the document is updated
         update_lead_status_on_mockup_design(self)
 
+    def check_image_field_in_lead_details(self):
+        """Ensure each row in the Lead Details table has an image before saving."""
+        for row in self.get("lead_details"):
+            if not row.image:
+                frappe.throw(f"Please add an image in row {row.idx} of the Lead Details table.")
 
 def update_lead_status_on_mockup_design(doc):
     """Update the status of the associated lead when the mockup design is approved or rejected."""

--- a/versa_system/versa_system/doctype/mockup_details/mockup_details.json
+++ b/versa_system/versa_system/doctype/mockup_details/mockup_details.json
@@ -1,0 +1,91 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-11-19 09:17:28.098715",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_iwf6",
+  "item",
+  "rate_range",
+  "design",
+  "model",
+  "size",
+  "colour",
+  "material",
+  "image"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_iwf6",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": " Item",
+   "options": "Item"
+  },
+  {
+   "fieldname": "rate_range",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Rate Range",
+   "options": "100 -1000\n1000-10000\n10000-20000\n20000-50000\n50000 above"
+  },
+  {
+   "fieldname": "design",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Design",
+   "options": "Design"
+  },
+  {
+   "fieldname": "model",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Model",
+   "options": "Model"
+  },
+  {
+   "fieldname": "size",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Size",
+   "options": "Size Chart"
+  },
+  {
+   "fieldname": "colour",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": " Colour",
+   "options": "Color"
+  },
+  {
+   "fieldname": "material",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Material",
+   "options": "Item"
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach Image",
+   "label": "Image"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-11-19 09:23:50.583824",
+ "modified_by": "Administrator",
+ "module": "Versa System",
+ "name": "Mockup Details",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/versa_system/versa_system/doctype/mockup_details/mockup_details.py
+++ b/versa_system/versa_system/doctype/mockup_details/mockup_details.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class MockupDetails(Document):
+	pass


### PR DESCRIPTION
## Feature description
  Implement functionality to ensure that an image is mandatory in the Lead module. Additionally, require at least one image to 
  be approved before the Lead can proceed to the next stage or status
## Solution description
- Image Field Validation: Add a mandatory validation to the image field in the Lead DocType. Ensure that at least one image is 
  uploaded before saving or submitting the form.

- Approval Requirement: Introduce a mechanism to track image approvals. Add a custom checkbox or status field (e.g., 
  "Approved") for each uploaded image. Validate that at least one image has the "Approved" status before allowing the Lead to 
  move to the next stage.
## Output
![Screenshot 2024-11-19 140239](https://github.com/user-attachments/assets/3d7ee7b9-0b6a-4bd1-a744-5dc0275527bd)
![Screenshot 2024-11-19 140320](https://github.com/user-attachments/assets/f56a9f26-9a42-43af-95b5-fba814306a73)

## Areas affected and ensured
- Lead DocType 
- Image mandatory Process in Mockup Design

## Is there any existing behavior change of other features due to this code change?
- Lead DocType and its image handling in Mockup Design
## Was this feature tested on the browsers?
  - Windows Edge