### PR TITLE
Update lead status on feasibility check approval and feasibility check rejection

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -94,9 +94,6 @@ function updateAndNavigateToLead(frm) {
     if (!frm.doc.from_lead) {
       frappe.msgprint(__("Please select a Lead before proceeding."));
       return;
-    callback: function(response) {
-      if (response.message) {
-      }
     }
   });
 }

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -41,8 +41,8 @@ def map_feasibility_to_mockup_design(source_name, target_doc=None):
                 "doctype": "Mockup Design",
                 "field_map": {}
             },
-            "Enqury Details": {  # Ensure this matches the target child table name
-                "doctype": "Enqury Details",  # Corrected spelling
+            "Enquiry Details": {  # Ensure this matches the target child table name
+                "doctype": "Enquiry Details",  # Corrected spelling
                 "postprocess": filter_approved_items,  # Process only approved items
                 "condition": lambda doc: doc.approve  # Only map rows where 'approve' is checked
             }
@@ -53,29 +53,16 @@ def map_feasibility_to_mockup_design(source_name, target_doc=None):
 
     return target_doc
 
-
 def update_lead_status_on_feasibility_check(doc):
     """Update the status of the associated lead when the feasibility check is approved or rejected."""
     if doc.from_lead:
-        try:
-            # Fetch the linked lead document
-            lead = frappe.get_doc("Lead", doc.from_lead)
-            
-            # Update status based on workflow state
-            if doc.workflow_state == "Approved":
-                lead.status = "Feasibility Check Approved"
-            elif doc.workflow_state == "Rejected":
-                lead.status = "Feasibility Check Rejected"
-            
-            lead.save()
+        # Fetch the linked lead document
+        lead = frappe.get_doc("Lead", doc.from_lead)
 
-            # Display success message
-            frappe.msgprint(
-                f"Lead {lead.name} status updated to '{lead.status}'.",
-                alert=True
-            )
-        except frappe.DoesNotExistError:
-            frappe.throw(f"The lead {doc.from_lead} does not exist.")
-        except Exception as e:
-            frappe.log_error(f"Failed to update lead status: {str(e)}")
-            frappe.throw("An error occurred while updating the lead status.")
+        # Update status based on workflow state
+        if doc.workflow_state == "Approved":
+            lead.status = "Feasibility Check Approved"  # Correct status
+        elif doc.workflow_state == "Rejected":
+            lead.status = "Feasibility Check Rejected"  # Correct status
+
+        lead.save()


### PR DESCRIPTION
## Feature description
Need to fix the lead status on feasibility check approval and feasibility check rejection based on the python code

## Solution description
Updated lead status on feasibility check approval and feasibility check rejection by changing code feasibility check .js  to feasibility check.py
## Output
![image](https://github.com/user-attachments/assets/12657b60-bc35-49dd-885f-d5ea8d60b5dc)
![image](https://github.com/user-attachments/assets/e3868095-3180-4a82-8d9b-5b727a9d12c4)
![image](https://github.com/user-attachments/assets/5c2f14b9-f61f-4d06-86f4-672f97d52ef0)
![image](https://github.com/user-attachments/assets/415e6c49-7bee-4bbe-b3d7-f2932fb1e1cf)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox