### PR TITLE
Update lead status on Mockup Design approval,rejection and on review

### DIFF
--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -1,14 +1,16 @@
 frappe.ui.form.on('Mockup Design', {
     refresh: function (frm) {
         // Ensure the form is saved before adding buttons
-        if (!frm.is_new()){
+        if (!frm.is_new()) {
             // Add a custom button to navigate to the linked Lead
-            frm.add_custom_button(__("Go to Lead"), function () {
-                frappe.set_route("Form", "Lead", frm.doc.from_lead);
-            });
+            if (frm.doc.from_lead) {
+                frm.add_custom_button(__('Go to Lead'), function () {
+                    frappe.set_route('Form', 'Lead', frm.doc.from_lead);
+                });
+            }
         }
 
-        // Check if the workflow state is "Approved"
+        // Add a 'Quotation' button if the workflow state is 'Approved'
         if (frm.doc.workflow_state === 'Approved') {
             frm.add_custom_button(__('Quotation'), function () {
                 frappe.model.open_mapped_doc({
@@ -19,107 +21,11 @@ frappe.ui.form.on('Mockup Design', {
         }
     },
 
-
-    after_save: function(frm) {
-        // Check if the current status is 'Feasibility Check Approved' and update it to 'opportunity'
+    after_save: function (frm) {
+        // Update the status to 'Opportunity' if it matches 'Feasibility Check Approved'
         if (frm.doc.status === 'Feasibility Check Approved') {
-            frm.set_value('status', 'opportunity');
-            frm.refresh_field('status'); // Refresh field on UI
+            frm.set_value('status', 'Opportunity');
+            frm.save(); // Save the document to persist the updated status
         }
-    },
-
-    approve: function(frm) {
-        // Approve the mockup design and update lead status if linked
-        if (frm.doc.is_approved) {
-            frm.set_value('status', 'Mockup Design Approved');
-            frm.refresh_field('status'); // Refresh UI before save
-
-            // Update the linked lead's status if applicable
-            if (frm.doc.from_lead) {
-                frappe.call({
-                    method: 'frappe.client.set_value',
-                    args: {
-                        doctype: 'Lead',
-                        name: frm.doc.from_lead,
-                        fieldname: 'status',
-                        value: 'Mockup Design Approved',
-                    },
-                    callback: function(response) {
-                        if (response && !response.exc) {
-                            frappe.msgprint(
-                                `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Approved'.`,
-                                'Status Updated'
-                            );
-                        } else {
-                            frappe.msgprint('Failed to update lead status.', 'Error');
-                        }
-                    }
-                });
-            }
-
-            frm.save(); // Save the document after status update
-        }
-    },
-
-    reject: function(frm) {
-        // Reject the mockup design and update lead status if linked
-        frm.set_value('status', 'Mockup Design Rejected');
-        frm.refresh_field('status'); // Refresh UI before save
-
-        // Update the linked lead's status if applicable
-        if (frm.doc.from_lead) {
-            frappe.call({
-                method: 'frappe.client.set_value',
-                args: {
-                    doctype: 'Lead',
-                    name: frm.doc.from_lead,
-                    fieldname: 'status',
-                    value: 'Mockup Design Rejected',
-                },
-                callback: function(response) {
-                    if (response && !response.exc) {
-                        frappe.msgprint(
-                            `Lead ${frm.doc.from_lead} status updated to 'Mockup Design Rejected'.`,
-                            'Status Updated'
-                        );
-                    } else {
-                        frappe.msgprint('Failed to update lead status.', 'Error');
-                    }
-                }
-            });
-        }
-
-        frm.save(); // Save the document to persist the rejection
-    },
-
-    review_request: function(frm) {
-        // Set the mockup design to 'On Review' and update lead status if linked
-        frm.set_value('status', 'On Review');
-        frm.refresh_field('status'); // Refresh UI before save
-
-        // Update the linked lead's status if applicable
-        if (frm.doc.from_lead) {
-            frappe.call({
-                method: 'frappe.client.set_value',
-                args: {
-                    doctype: 'Lead',
-                    name: frm.doc.from_lead,
-                    fieldname: 'status',
-                    value: 'On Review',
-                },
-                callback: function(response) {
-                    if (response && !response.exc) {
-                        frappe.msgprint(
-                            `Lead ${frm.doc.from_lead} status updated to 'On Review'.`,
-                            'Status Updated'
-                        );
-                    } else {
-                        frappe.msgprint('Failed to update lead status.', 'Error');
-                    }
-                }
-            });
-        }
-
-        frm.save(); // Save the document to persist the review status
     }
 });

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.js
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.js
@@ -19,13 +19,5 @@ frappe.ui.form.on('Mockup Design', {
                 });
             }, __('Create'));
         }
-    },
-
-    after_save: function (frm) {
-        // Update the status to 'Opportunity' if it matches 'Feasibility Check Approved'
-        if (frm.doc.status === 'Feasibility Check Approved') {
-            frm.set_value('status', 'Opportunity');
-            frm.save(); // Save the document to persist the updated status
-        }
-    }
+    }  
 });

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
+
 class MockupDesign(Document):
     def validate(self):
         # Ensure each row in lead_details table has an image
@@ -17,38 +18,6 @@ class MockupDesign(Document):
             if not row.image:
                 frappe.throw(f"Please add an image in row {row.idx} of the Lead Details table.")
 
-def update_lead_status_on_mockup_design(doc):
-    """Update the status of the associated lead when the mockup design is approved or rejected."""
-    if doc.from_lead:
-        try:
-            # Fetch the linked lead document
-            lead = frappe.get_doc("Lead", doc.from_lead)
-
-            # Update status based on workflow state
-            if doc.workflow_state == "Approved":
-                lead.status = "Mockup Design Approved"
-            elif doc.workflow_state == "Rejected":
-                lead.status = "Mockup Design Rejected"
-            elif doc.workflow_state == "Review Request":
-                lead.status = "On Review"
-            else:
-                # Optional: You could add an else block for other states if needed
-                pass
-
-            # Save the lead document to commit the status change
-            lead.save()
-
-            # Display success message
-            frappe.msgprint(
-                f"Lead {lead.name} status updated to '{lead.status}'.",
-                alert=True
-            )
-        except frappe.DoesNotExistError:
-            frappe.throw(f"The lead {doc.from_lead} does not exist.")
-        except Exception as e:
-            # Log the error for debugging purposes
-            frappe.log_error(f"Failed to update lead status: {str(e)}")
-            frappe.throw("An error occurred while updating the lead status.")
 
 @frappe.whitelist()
 def map_mockup_design_to_quotation(source_name, target_doc=None):
@@ -59,7 +28,10 @@ def map_mockup_design_to_quotation(source_name, target_doc=None):
         target.quotation_to = "Mockup Design"
         target.party_name = source.name
         target.customer_name = source.from_lead
-    target_doc = get_mapped_doc("Mockup Design", source_name,
+
+    target_doc = get_mapped_doc(
+        "Mockup Design",
+        source_name,
         {
             "Mockup Design": {
                 "doctype": "Quotation",
@@ -67,14 +39,35 @@ def map_mockup_design_to_quotation(source_name, target_doc=None):
                     "from_lead": "party_name"
                 },
             },
-            "Enqury Details": {  # Assuming the child table in Lead is 'lead_items'
+            "Enquiry Details": {  # Assuming the child table in Lead is 'lead_items'
                 "doctype": "Quotation Item",  # Actual child table DocType is 'Quotation Item'
                 "field_map": {
                     "item": "item_name",
                     "item": "item_code",
-                     # Map the rate if available
+                    # Map the rate if available
                 }
             }
-        }, target_doc, set_missing_values)
+        },
+        target_doc,
+        set_missing_values,
+    )
 
     return target_doc
+
+
+def update_lead_status_on_mockup_design(doc):
+    """Update the status of the associated lead when the mockup design is updated."""
+    if doc.from_lead:
+        # Fetch the linked lead document
+        lead = frappe.get_doc("Lead", doc.from_lead)
+
+        # Update status based on workflow state
+        if doc.workflow_state == "Approved":
+            lead.status = "Mockup Design Approved"
+        elif doc.workflow_state == "Rejected":
+            lead.status = "Mockup Design Rejected"
+        elif doc.workflow_state == "Review Request":
+            lead.status = "On Review"
+
+        # Save the lead document to commit the status change
+        lead.save()


### PR DESCRIPTION
## Feature description
Need to Update lead status on Mockup Design approval,rejection and on review based on the python code

## Solution description
Updated lead status on mockup design approval,rejection and on review by changing code mockup design.js to mockup design.py
## Output
![image](https://github.com/user-attachments/assets/7454ac38-2d9d-4e88-827f-3e19b5294f18)
![image](https://github.com/user-attachments/assets/062518fe-b4ba-47fc-9aec-0733aeb6d4df)
![image](https://github.com/user-attachments/assets/e07d397a-5122-40c6-9b90-2cfacffe71fe)
![image](https://github.com/user-attachments/assets/af3fc116-2943-48e3-a622-0637800ac9de)
![image](https://github.com/user-attachments/assets/790db016-6bff-4e35-8211-76ec80b008d3)
![image](https://github.com/user-attachments/assets/c93813e5-6640-4dc3-a789-eac057b5e015)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox