### PR TITLE
Fix the issues in Feasibility Check Doctype and Mockup Design Doctype

### DIFF
--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -41,8 +41,8 @@ def map_feasibility_to_mockup_design(source_name, target_doc=None):
                 "doctype": "Mockup Design",
                 "field_map": {}
             },
-            "Enquiry Details": {  # Ensure this matches the target child table name
-                "doctype": "Enquiry Details",  # Corrected spelling
+            "Enqury Details": {  
+                "doctype": "Enqury Details",
                 "postprocess": filter_approved_items,  # Process only approved items
                 "condition": lambda doc: doc.approve  # Only map rows where 'approve' is checked
             }

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -25,9 +25,8 @@ def map_mockup_design_to_quotation(source_name, target_doc=None):
     Map fields from Mockup Design DocType to Quotation DocType.
     """
     def set_missing_values(source, target):
-        target.quotation_to = "Mockup Design"
-        target.party_name = source.name
-        target.customer_name = source.from_lead
+        target.quotation_to = "Lead"
+        target.party_name = source.from_lead
 
     target_doc = get_mapped_doc(
         "Mockup Design",

--- a/versa_system/versa_system/doctype/mockup_design/mockup_design.py
+++ b/versa_system/versa_system/doctype/mockup_design/mockup_design.py
@@ -38,7 +38,7 @@ def map_mockup_design_to_quotation(source_name, target_doc=None):
                     "from_lead": "party_name"
                 },
             },
-            "Enquiry Details": {  # Assuming the child table in Lead is 'lead_items'
+            "Enqury Details": {  # Assuming the child table in Lead is 'lead_items'
                 "doctype": "Quotation Item",  # Actual child table DocType is 'Quotation Item'
                 "field_map": {
                     "item": "item_name",


### PR DESCRIPTION
## Feature description
Need to: Fix the issues in Feasibility Check Doctype and Mockup Design Doctype

## Solution description
Fixed the issues in Feasibility Check Doctype  while mapping Feasibility CheckDoctype to Mockup Design Doctype.
Changed the code in Mockup Design.py  "Quotation To" field from Mockup Design to Lead while mapping mockup design doctype to quotation doctype
## Output
![image](https://github.com/user-attachments/assets/f3a26113-081c-46f3-ac14-f3d9b5d93fdc)
![image](https://github.com/user-attachments/assets/2134ea9b-092e-4de9-a5c5-b9f8b7e2623b)
![image](https://github.com/user-attachments/assets/410c65f2-b886-448b-8660-24d36742bf07)
![image](https://github.com/user-attachments/assets/5621174e-d821-4533-9f93-b1b9143996e9)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox