### PR TITLE
Versa3  Add new doctype size chart

### DIFF
--- a/versa_system/versa_system/doctype/item_details/item_details.json
+++ b/versa_system/versa_system/doctype/item_details/item_details.json
@@ -11,8 +11,9 @@
   "design",
   "model",
   "brand",
-  "rate_range",
   "made",
+  "size_chart",
+  "rate_range",
   "is_customized",
   "image"
  ],
@@ -20,36 +21,42 @@
   {
    "fieldname": "item",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Item",
    "options": "Item"
   },
   {
    "fieldname": "design",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Design",
    "options": "Design"
   },
   {
    "fieldname": "model",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Model",
    "options": "Model"
   },
   {
    "fieldname": "brand",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Brand",
    "options": "Brand"
   },
   {
    "fieldname": "rate_range",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Rate Range",
    "options": "Rate Range"
   },
   {
    "fieldname": "made",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Made",
    "options": "Hand Made\nMachine Made"
   },
@@ -57,25 +64,35 @@
    "default": "0",
    "fieldname": "is_customized",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Is customized"
   },
   {
    "fieldname": "image",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Image",
    "options": "Image"
   },
   {
    "fieldname": "material",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Material",
    "options": "Item"
+  },
+  {
+   "fieldname": "size_chart",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Size Chart",
+   "options": "Size Chart"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-10 13:17:14.346156",
+ "modified": "2024-12-10 14:38:45.068079",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Item Details",

--- a/versa_system/versa_system/doctype/size_chart/size_chart.js
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, efeone and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Size Chart", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/versa_system/versa_system/doctype/size_chart/size_chart.json
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-12-10 14:28:54.738998",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_38zo",
+  "size_chart"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_38zo",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "size_chart",
+   "fieldtype": "Data",
+   "label": "Size Chart"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-12-10 14:30:48.847974",
+ "modified_by": "Administrator",
+ "module": "Versa System",
+ "name": "Size Chart",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/versa_system/versa_system/doctype/size_chart/size_chart.py
+++ b/versa_system/versa_system/doctype/size_chart/size_chart.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SizeChart(Document):
+	pass

--- a/versa_system/versa_system/doctype/size_chart/test_size_chart.py
+++ b/versa_system/versa_system/doctype/size_chart/test_size_chart.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSizeChart(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
Need to Create Doctype size chart .
Need to add a field size chart in child doctype Item details. 

## Solution description
Created Doctype size chart .
Added a field size chart in child doctype Item details.  
## Output
![image](https://github.com/user-attachments/assets/15ab7b31-532a-4fbd-b7f1-e9eccb85c367)


## Areas affected and ensured
-New doctype

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox