### PR TITLE
feat:Hide feasibility feild in Lead

### DIFF
--- a/versa_system/versa_system/doctype/item_details/item_details.json
+++ b/versa_system/versa_system/doctype/item_details/item_details.json
@@ -13,9 +13,9 @@
   "brand",
   "made",
   "size_chart",
-  "rate_range",
+  "image",
   "is_customized",
-  "image"
+  "is_feasible"
  ],
  "fields": [
   {
@@ -47,13 +47,7 @@
    "options": "Brand"
   },
   {
-   "fieldname": "rate_range",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Rate Range",
-   "options": "Rate Range"
-  },
-  {
+   "default": "Machine Made",
    "fieldname": "made",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -64,15 +58,14 @@
    "default": "0",
    "fieldname": "is_customized",
    "fieldtype": "Check",
+   "hidden": 1,
    "in_list_view": 1,
    "label": "Is customized"
   },
   {
    "fieldname": "image",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Image",
-   "options": "Image"
+   "fieldtype": "Attach Image",
+   "label": "Image"
   },
   {
    "fieldname": "material",
@@ -87,12 +80,19 @@
    "in_list_view": 1,
    "label": "Size Chart",
    "options": "Size Chart"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:['Lead', 'Item Details'].includes(doc.parenttype)\n",
+   "fieldname": "is_feasible",
+   "fieldtype": "Check",
+   "label": "Is Feasible"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-10 14:38:45.068079",
+ "modified": "2024-12-12 13:23:55.949262",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Item Details",


### PR DESCRIPTION
## Feature description
add is feasable field in child 
doc item detalis (check) is hide in lead and 
visible in feasability check
delete image doc and add a field as image (atttach)
## Solution description
Hided feasibility feild in lead
added image as field
## Output
![image](https://github.com/user-attachments/assets/47e7ff4f-f56a-4e35-8075-218aa8559d1e)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox