### PR TITLE
Add quotation button in lead and create new quotation by fetching details in the lead.

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -129,10 +129,10 @@ doctype_js = {
 # Hook on document methods and events
 
 # doc_events = {
-# 	"*": {
-# 		"on_update": "method",
-# 		"on_cancel": "method",
-# 		"on_trash": "method"
+# 	"Lead": {
+# 		"on_save": "versa_system.versa_system.custom_script.lead.map_lead_to_quotation",
+# # 		# "on_cancel": "method",
+# # 		# "on_trash": "method"
 # 	}
 # }
 

--- a/versa_system/public/lead.js
+++ b/versa_system/public/lead.js
@@ -1,5 +1,5 @@
 frappe.ui.form.on('Lead', {
-    refresh: function (frm) {
+    refresh: function(frm) {
         // Filter for custom item details
         frm.fields_dict['custom_item_details'].grid.get_field('item').get_query = function(doc, cdt, cdn) {
             return {
@@ -8,6 +8,7 @@ frappe.ui.form.on('Lead', {
                 ]
             };
         };
+
         frm.fields_dict['custom_item_details'].grid.get_field('material').get_query = function(doc, cdt, cdn) {
             return {
                 filters: [
@@ -16,17 +17,27 @@ frappe.ui.form.on('Lead', {
             };
         };
 
+        // Add "Feasibility Check" button
         frm.add_custom_button(
-          __("Feasibility Check"),
-          function () {
-            frappe.model.open_mapped_doc({
-              method:
-                "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_lead_to_feasibility_check",
-              frm: frm,
-            });
-          },
-          __("Create")
+            __("Feasibility Check"),
+            function () {
+                frappe.model.open_mapped_doc({
+                    method: "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_lead_to_feasibility_check",
+                    frm: frm,
+                });
+            },
+            __("Create")
         );
 
+        // Add "Create Quotation" button
+        if (!frm.is_new()) {
+            frm.page.remove_inner_button(__('Quotation'), 'Create');
+            frm.add_custom_button(__('Quotation'), function() {
+                frappe.model.open_mapped_doc({
+                    method: 'versa_system.versa_system.custom_script.quotation.map_lead_to_quotation',
+                    frm: frm
+                });
+            }, __('Create'));
+        }
     }
 });

--- a/versa_system/versa_system/custom_script/quotation.py
+++ b/versa_system/versa_system/custom_script/quotation.py
@@ -1,0 +1,41 @@
+import frappe
+from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
+
+class Quotation(Document):
+    pass
+
+@frappe.whitelist()
+def map_lead_to_quotation(source_name, target_doc=None):
+    """
+    Map fields from Lead DocType to Quotation DocType,
+    including child table 'Item Details'
+    """
+    def set_missing_values(source, target):
+        target.quotation_to = "Lead"
+        target.party_name = source.name
+
+    def filter_approved_items(source, target, source_parent):
+        # Only map rows where the 'approve' checkbox is checked
+        if source.approve:
+            target.item_name = source.item
+            target.item_code = source.item  # Allow creating the quotation even if the user does not have permissions
+
+    target_doc = get_mapped_doc("Lead", source_name,
+        {
+            "Lead": {
+                "doctype": "Quotation",
+                "field_map": {
+                    "lead_name": "customer_name",  # Example: Map Lead's 'lead_name' to Quotation's 'customer_name'
+                    "email_id": "contact_email"  # Example: Map Lead's 'email_id' to Quotation's 'contact_email'
+                },
+            },
+            "Item Details": {  # Correct child table name in Lead
+                "doctype": "Quotation Item",  # Correct child table name in Quotation
+                "field_map": {
+                    "item": "item_code"
+                }
+            }
+        }, target_doc, set_missing_values)
+
+    return target_doc


### PR DESCRIPTION
## Feature description
Add button from lead to quotation.
Create new quotation by fetching the lead details.

## Solution description
Remove the existing button in the lead and add new quotation button to create quotation.
Quotation created by fetching details in the lead.
## Output
![image](https://github.com/user-attachments/assets/0c2a7c1b-a99a-4ce5-8e2c-7a449234c1ed)

## Areas affected and ensured
-New feature (Quotation)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox