### PR TITLE
feat: Add button in quotation,type position changed

### DIFF
--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -2,6 +2,146 @@
  {
   "docstatus": 0,
   "doctype": "Workflow",
+  "document_type": "Quotation",
+  "is_active": 1,
+  "modified": "2024-12-17 17:13:16.916385",
+  "name": "Quotation Workflow",
+  "override_status": 0,
+  "send_email_alert": 0,
+  "states": [
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Quotation Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Quotation Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Quotation Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Approved",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Quotation Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Rejected",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Quotation Workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Review Request",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Quotation Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Approved",
+    "parent": "Quotation Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Rejected",
+    "parent": "Quotation Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Review Request",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Draft",
+    "parent": "Quotation Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "workflow_builder_id": null
+   }
+  ],
+  "workflow_data": null,
+  "workflow_name": "Quotation Workflow",
+  "workflow_state_field": "workflow_state"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
   "document_type": "Design Request",
   "is_active": 1,
   "modified": "2024-12-16 10:55:09.854148",
@@ -86,6 +226,18 @@
    }
   ],
   "transitions": [
+   {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Mockup Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
@@ -211,6 +363,18 @@
    }
   ],
   "transitions": [
+   {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Feasibility workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,

--- a/versa_system/fixtures/workflow_transition.json
+++ b/versa_system/fixtures/workflow_transition.json
@@ -1,0 +1,50 @@
+[
+ {
+  "action": "Send to customer",
+  "allow_self_approval": 1,
+  "allowed": "Administrator",
+  "condition": null,
+  "docstatus": 0,
+  "doctype": "Workflow Transition",
+  "modified": "2024-12-13 15:32:51.989162",
+  "name": "kt5il738bk",
+  "next_state": "Send to customer",
+  "parent": "Quotation Workflow",
+  "parentfield": "transitions",
+  "parenttype": "Workflow",
+  "state": "Draft",
+  "workflow_builder_id": null
+ },
+ {
+  "action": "Send to Customer",
+  "allow_self_approval": 1,
+  "allowed": "Administrator",
+  "condition": null,
+  "docstatus": 0,
+  "doctype": "Workflow Transition",
+  "modified": "2024-12-17 16:16:54.064915",
+  "name": "nt1rrp2aat",
+  "next_state": "Send to Customer",
+  "parent": "Mockup Workflow",
+  "parentfield": "transitions",
+  "parenttype": "Workflow",
+  "state": "Draft",
+  "workflow_builder_id": null
+ },
+ {
+  "action": "Send to Customer",
+  "allow_self_approval": 1,
+  "allowed": "Administrator",
+  "condition": null,
+  "docstatus": 0,
+  "doctype": "Workflow Transition",
+  "modified": "2024-12-17 16:16:54.237567",
+  "name": "v4b60oknig",
+  "next_state": "Send to Customer",
+  "parent": "Feasibility workflow",
+  "parentfield": "transitions",
+  "parenttype": "Workflow",
+  "state": "Draft",
+  "workflow_builder_id": null
+ }
+]

--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -7,7 +7,8 @@ app_license = "mit"
 
 
 doctype_js = {
-    "Lead": "public/lead.js"
+    "Lead": "public/lead.js",
+    "Quotation": "public/quotation.js"
 }
 
 # required_apps = []
@@ -236,7 +237,7 @@ fixtures = [
     {
         "dt": "Workflow",
         "filters": [
-            ["name", "in", ["Feasibility workflow","Mockup Workflow"]]
+            ["name", "in", ["Feasibility workflow","Mockup Workflow","Quotation Workflow"]]
         ]
     },
     {

--- a/versa_system/public/quotation.js
+++ b/versa_system/public/quotation.js
@@ -1,0 +1,13 @@
+frappe.ui.form.on('Quotation', {
+    refresh: function(frm) {
+        if (frm.doc.workflow_state === "Approved") {
+            frm.add_custom_button(__('Go to Lead'), function() {
+                if (frm.doc.party_name) {
+                    frappe.set_route('Form', 'Lead', frm.doc.party_name);
+                } else {
+                    frappe.msgprint(__('No Lead is linked to the Quotation.'));
+                }
+            })
+        }
+    }
+});

--- a/versa_system/versa_system/doctype/design_request/design_request.json
+++ b/versa_system/versa_system/doctype/design_request/design_request.json
@@ -7,11 +7,11 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_34ns",
+  "type",
   "amended_from",
   "lead",
   "first_name",
-  "item_details",
-  "type"
+  "item_details"
  ],
  "fields": [
   {
@@ -56,7 +56,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-12 16:10:21.658285",
+ "modified": "2024-12-18 10:56:08.949380",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design Request",


### PR DESCRIPTION
## Feature description
Create a button in quotation, it shows  when quotation is approved ,
then go to LEAD with full details
change position of type in design request to topper of the page

## Solution description
Created a button from quotation for go to lead  when customer approve quotation
Position changed for type of design
## Output
![image](https://github.com/user-attachments/assets/acef7cd5-986a-4237-a40f-bcc94d4bfe0d)
![image](https://github.com/user-attachments/assets/b77e8439-152e-48a6-b12a-833ef78ddade)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox