### PR TITLE
feat:final image shows only when type is final design

### DIFF
--- a/versa_system/versa_system/doctype/design_request/design_request.json
+++ b/versa_system/versa_system/doctype/design_request/design_request.json
@@ -11,6 +11,7 @@
   "amended_from",
   "lead",
   "first_name",
+  "final_image",
   "item_details"
  ],
  "fields": [
@@ -51,12 +52,18 @@
    "fieldtype": "Select",
    "label": "Type",
    "options": "Mockup Design\nFinal Design"
+  },
+  {
+   "depends_on": "eval: doc.type == 'Final Design'\n",
+   "fieldname": "final_image",
+   "fieldtype": "Attach Image",
+   "label": "Final Image"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-18 10:56:08.949380",
+ "modified": "2024-12-18 16:18:24.476549",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design Request",


### PR DESCRIPTION
## Feature description
Add image field in design request when it shows only in final design type

## Solution description
Added image field in design request doctype when it only shows in final design type
## Output
![Screenshot from 2024-12-18 16-29-28](https://github.com/user-attachments/assets/5aab2ed9-8764-4b2a-be72-e9e5256322e0)
![Screenshot from 2024-12-18 16-29-39](https://github.com/user-attachments/assets/5fec7522-1d27-4054-81b3-a459c3f13bfe)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox