### PR TITLE
fix:quotation workflow updated

### DIFF
--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -4,7 +4,7 @@
   "doctype": "Workflow",
   "document_type": "Quotation",
   "is_active": 1,
-  "modified": "2024-12-17 17:13:16.916385",
+  "modified": "2024-12-19 09:57:24.225556",
   "name": "Quotation Workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -86,18 +86,6 @@
    }
   ],
   "transitions": [
-   {
-    "action": "Send to customer",
-    "allow_self_approval": 1,
-    "allowed": "Administrator",
-    "condition": null,
-    "next_state": "Send to customer",
-    "parent": "Quotation Workflow",
-    "parentfield": "transitions",
-    "parenttype": "Workflow",
-    "state": "Draft",
-    "workflow_builder_id": null
-   },
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,

--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -87,6 +87,18 @@
   ],
   "transitions": [
    {
+    "action": "Send to customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to customer",
+    "parent": "Quotation Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
+   {
     "action": "Send to Customer",
     "allow_self_approval": 1,
     "allowed": "Administrator",
@@ -251,6 +263,18 @@
     "workflow_builder_id": null
    },
    {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Mockup Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
+   {
     "action": "Approve",
     "allow_self_approval": 1,
     "allowed": "Administrator",
@@ -363,6 +387,18 @@
    }
   ],
   "transitions": [
+   {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Feasibility workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,


### PR DESCRIPTION
## Feature description
Remove send to customer that is already have two same

## Solution description
Removed send to customer state
## Output
![image](https://github.com/user-attachments/assets/e8931053-ed04-4a42-93f5-ff8f1ee5c5e3)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox