### PR TITLE
feat:Add Button in Lead

### DIFF
--- a/versa_system/public/lead.js
+++ b/versa_system/public/lead.js
@@ -29,6 +29,17 @@ frappe.ui.form.on('Lead', {
             __("Create")
         );
 
+                frm.add_custom_button(
+                    __("Go to Final Design"),
+                    function () {
+                        frappe.model.open_mapped_doc({
+                            method: "versa_system.versa_system.doctype.design_request.design_request.map_lead_to_design_request",
+                            frm: frm,
+                        });
+                    },
+                    __("Create")
+                );
+
         // Add "Create Quotation" button
         if (!frm.is_new()) {
             frm.page.remove_inner_button(__('Quotation'), 'Create');

--- a/versa_system/versa_system/doctype/design_request/design_request.py
+++ b/versa_system/versa_system/doctype/design_request/design_request.py
@@ -6,6 +6,7 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
 
+
 class DesignRequest(Document):
 	pass
 @frappe.whitelist()
@@ -39,3 +40,35 @@ def map_feasibility_check_to_moc(source_name, target_doc=None):
         }, target_doc, set_missing_values)
 
     return target_doc.save()
+
+@frappe.whitelist()
+def map_lead_to_design_request(source_name, target_doc=None):
+    """
+    Map fields from Lead DocType to Design Request DocType,
+    including child table 'Enquiry Details'
+    """
+    def set_missing_values(source, target):
+        # Set any missing values if needed
+        target.type = "Final Design"
+
+    target_doc = get_mapped_doc("Lead", source_name,
+        {
+            "Lead": {
+                "doctype": "Design Request",
+                "field_map": {},
+            },
+            "Item Details": {  # Ensure that 'Item Details' is the correct child table name
+                "doctype": "Item Details",  # Ensure this matches the target child table
+                "field_map": {
+                    "item": "item",
+                    "material": "material",
+                    "brand": "brand",
+                    "model": "model",
+                    "rate_range": "rate_range",
+                    "size": "size",
+                    "design": "design",
+                }
+            }
+        }, target_doc, set_missing_values)
+
+    return target_doc


### PR DESCRIPTION
## Feature description
Add a button in lead named 'Go to Final Design'

## Solution description
Added button in the lead named  'Go to Final Design'
when clicked 'Go to Final Design' it mapped to Design Request doctype 
## Output
![image](https://github.com/user-attachments/assets/ae7b93cd-472f-4a35-9e28-144c913702bf)

## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox