### PR TITLE
feat:add workflow for Design Request

### DIFF
--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -2,6 +2,131 @@
  {
   "docstatus": 0,
   "doctype": "Workflow",
+  "document_type": "Design Request",
+  "is_active": 0,
+  "modified": "2024-12-19 16:04:12.197154",
+  "name": "Design Request workflow",
+  "override_status": 0,
+  "send_email_alert": 0,
+  "states": [
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Design Request workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "0",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Design Request workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Design Request workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Approved",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   },
+   {
+    "allow_edit": "Administrator",
+    "avoid_status_override": 0,
+    "doc_status": "1",
+    "is_optional_state": 0,
+    "message": null,
+    "next_action_email_template": null,
+    "parent": "Design Request workflow",
+    "parentfield": "states",
+    "parenttype": "Workflow",
+    "state": "Rejected",
+    "update_field": null,
+    "update_value": null,
+    "workflow_builder_id": null
+   }
+  ],
+  "transitions": [
+   {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Design Request workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Review Request",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Draft",
+    "parent": "Design Request workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Approve",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Approved",
+    "parent": "Design Request workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "workflow_builder_id": null
+   },
+   {
+    "action": "Reject",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Rejected",
+    "parent": "Design Request workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Send to Customer",
+    "workflow_builder_id": null
+   }
+  ],
+  "workflow_data": null,
+  "workflow_name": "Design Request workflow",
+  "workflow_state_field": "workflow_state"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow",
   "document_type": "Quotation",
   "is_active": 1,
   "modified": "2024-12-19 10:22:38.125676",
@@ -87,6 +212,18 @@
   ],
   "transitions": [
    {
+    "action": "Send to customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to customer",
+    "parent": "Quotation Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
+   {
     "action": "Send to Customer",
     "allow_self_approval": 1,
     "allowed": "Administrator",
@@ -143,8 +280,8 @@
   "docstatus": 0,
   "doctype": "Workflow",
   "document_type": "Design Request",
-  "is_active": 1,
-  "modified": "2024-12-16 10:55:09.854148",
+  "is_active": 0,
+  "modified": "2024-12-20 10:27:22.821241",
   "name": "Mockup Workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -226,6 +363,18 @@
    }
   ],
   "transitions": [
+   {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Mockup Workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
@@ -375,6 +524,18 @@
    }
   ],
   "transitions": [
+   {
+    "action": "Send to Customer",
+    "allow_self_approval": 1,
+    "allowed": "Administrator",
+    "condition": null,
+    "next_state": "Send to Customer",
+    "parent": "Feasibility workflow",
+    "parentfield": "transitions",
+    "parenttype": "Workflow",
+    "state": "Draft",
+    "workflow_builder_id": null
+   },
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,

--- a/versa_system/fixtures/workflow_action_master.json
+++ b/versa_system/fixtures/workflow_action_master.json
@@ -16,15 +16,15 @@
  {
   "docstatus": 0,
   "doctype": "Workflow Action Master",
-  "modified": "2024-12-13 15:29:39.126493",
-  "name": "Send to Customer",
-  "workflow_action_name": "Send to Customer"
+  "modified": "2024-12-13 15:30:26.023984",
+  "name": "Review Request",
+  "workflow_action_name": "Review Request"
  },
  {
   "docstatus": 0,
   "doctype": "Workflow Action Master",
-  "modified": "2024-12-13 15:30:26.023984",
-  "name": "Review Request",
-  "workflow_action_name": "Review Request"
+  "modified": "2024-12-13 15:29:39.126493",
+  "name": "Send to Customer",
+  "workflow_action_name": "Send to Customer"
  }
 ]

--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -233,11 +233,18 @@ doctype_js = {
 # default_log_clearing_doctypes = {
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
+doc_events = {
+    "Design Request": {
+        "before_save":"versa_system.versa_system.doctype.design_request.design_request.set_workflow"
+    }
+}
+
+
 fixtures = [
     {
         "dt": "Workflow",
         "filters": [
-            ["name", "in", ["Feasibility workflow","Mockup Workflow","Quotation Workflow"]]
+            ["name", "in", ["Feasibility workflow","Mockup Workflow","Quotation Workflow","Design Request workflow"]]
         ]
     },
     {

--- a/versa_system/versa_system/doctype/design_request/design_request.py
+++ b/versa_system/versa_system/doctype/design_request/design_request.py
@@ -72,3 +72,12 @@ def map_lead_to_design_request(source_name, target_doc=None):
         }, target_doc, set_missing_values)
 
     return target_doc
+
+#Function to dynamically activate one workflow and deactivate another
+def set_workflow(doc, method):
+    if doc.type == "Mockup Design":
+        frappe.db.set_value("Workflow", {"name": "Mockup Workflow"}, "is_active", 1)
+        frappe.db.set_value("Workflow", {"name": "Final Design Workflow"}, "is_active", 0)
+    elif doc.type == "Final Design":
+        frappe.db.set_value("Workflow", {"name": "Mockup Workflow"}, "is_active", 0)
+        frappe.db.set_value("Workflow", {"name": "Final Design Workflow"}, "is_active", 1)


### PR DESCRIPTION
## Feature description
Added  workflow for Design Request

## Solution description
Added  workflow for Design Request
Added Function to activate one workflow and deactivate another dynamically, ie  if  type=Mockup Design then its workflow is activated else Final Design will be activated
## Output
![image](https://github.com/user-attachments/assets/f6140619-ca6d-43d8-8b29-db005d3d88d8)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox