### PR TITLE
feat: Add naming series and button in raw material request doctype

### DIFF
--- a/versa_system/versa_system/doctype/raw_material_request/raw_material_request.js
+++ b/versa_system/versa_system/doctype/raw_material_request/raw_material_request.js
@@ -6,3 +6,18 @@
 
 // 	},
 // });
+frappe.ui.form.on('Raw Material Request', {
+    refresh: function(frm) {
+        // Check if any row has 'is_available' unchecked
+        let show_button = frm.doc.item_details.some(row => row.is_available === 0 || row.is_available === false);
+
+        if (show_button) {
+            frm.add_custom_button(
+                __('Raw Material Purchase'),
+                function() {
+                    // Add button functionality here
+                }
+            );
+        }
+    }
+});

--- a/versa_system/versa_system/doctype/raw_material_request/raw_material_request.json
+++ b/versa_system/versa_system/doctype/raw_material_request/raw_material_request.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "RMR.#####",
  "creation": "2024-12-18 12:52:55.342065",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -35,10 +36,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-19 12:31:55.531663",
+ "modified": "2024-12-20 10:57:21.382218",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Raw Material Request",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
## Feature description
Need to add naming series and button in raw material request doctype 

## Solution description
Added naming series to raw material request doctype .
Added Raw Material Purchase button in raw material request doctype , button shows only when 'is available' field is unchecked.

## Output
![image](https://github.com/user-attachments/assets/f78034e6-c73d-4a1f-a03c-8f0d878a72f5)

## Areas affected and ensured
-New feature (button)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox