### PR TITLE
fix:change button name and change naming series

### DIFF
--- a/versa_system/versa_system/doctype/design_request/design_request.js
+++ b/versa_system/versa_system/doctype/design_request/design_request.js
@@ -5,7 +5,7 @@ frappe.ui.form.on('Design Request', {
     refresh: function(frm) {
       if (frm.doc.workflow_state === "Approved" && frm.doc.type === "Mockup Design") {
         // Add a custom button
-        frm.add_custom_button(__('Go to Lead'), function() {
+        frm.add_custom_button(__('View Lead'), function() {
             // Check if the 'lead' field exists and has a value
             if (frm.doc.lead) {
                 // Redirect to the specific Lead document

--- a/versa_system/versa_system/doctype/design_request/design_request.json
+++ b/versa_system/versa_system/doctype/design_request/design_request.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:first_name",
+ "autoname": "format:{type}-{#####} ",
  "creation": "2024-12-12 15:59:53.945997",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -63,11 +63,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-18 16:18:24.476549",
+ "modified": "2024-12-21 11:51:30.057312",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design Request",
- "naming_rule": "By fieldname",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
## Feature description
1. Change the button name go to 'lead' to "View Lead"
2. Add naming series for Mockup and Final design

## Solution description
1. Changed the button name go to 'lead' to "View Lead"
2. Added  naming series for Mockup and Final design ie, when type=Final design it saves as Final design.##### else save as Mockup.#####

## Output
![image](https://github.com/user-attachments/assets/19529bcf-2eee-4450-b819-b92b0b3324f6)
![image](https://github.com/user-attachments/assets/8b3f1fcb-acf0-4386-b24e-a412d2a327d6)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox