### PR TITLE
feat: Cannot able to change type in Design request after save the doctype

### DIFF
--- a/versa_system/versa_system/doctype/design_request/design_request.js
+++ b/versa_system/versa_system/doctype/design_request/design_request.js
@@ -1,10 +1,9 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
 
 frappe.ui.form.on('Design Request', {
     refresh: function(frm) {
         // Ensure the 'type' field is read-only if its value is 'Mockup Design'
-        if (frm.doc.type === 'Mockup Design') {
+        // and workflow_state is 'Sent to Customer'
+        if (frm.doc.type === 'Mockup Design' && frm.doc.workflow_state === 'Sent to Customer') {
             frm.set_df_property('type', 'read_only', 1);
         }
 
@@ -22,7 +21,8 @@ frappe.ui.form.on('Design Request', {
 
     type: function(frm) {
         // Make the 'type' field read-only if its value is 'Mockup Design'
-        if (frm.doc.type === 'Mockup Design') {
+        // and workflow_state is 'Sent to Customer'
+        if (frm.doc.type === 'Mockup Design' && frm.doc.workflow_state === 'Sent to Customer') {
             frm.set_df_property('type', 'read_only', 1);
         } else {
             frm.set_df_property('type', 'read_only', 0);

--- a/versa_system/versa_system/doctype/design_request/design_request.js
+++ b/versa_system/versa_system/doctype/design_request/design_request.js
@@ -3,17 +3,29 @@
 
 frappe.ui.form.on('Design Request', {
     refresh: function(frm) {
-      if (frm.doc.workflow_state === "Approved" && frm.doc.type === "Mockup Design") {
-        // Add a custom button
-        frm.add_custom_button(__('Go to Lead'), function() {
-            // Check if the 'lead' field exists and has a value
-            if (frm.doc.lead) {
-                // Redirect to the specific Lead document
-                frappe.set_route('Form', 'Lead', frm.doc.lead);
-            } else {
-                frappe.msgprint(__('No Lead is linked to this Design Request.'));
-            }
-        }, __('Create Quatation from Lead')); // Group under "Actions"
-      }
+        // Ensure the 'type' field is read-only if its value is 'Mockup Design'
+        if (frm.doc.type === 'Mockup Design') {
+            frm.set_df_property('type', 'read_only', 1);
+        }
+
+        // Add a custom button when the workflow_state is 'Approved'
+        if (frm.doc.workflow_state === "Approved") {
+            frm.add_custom_button(__('Go to Lead'), function() {
+                if (frm.doc.lead) {
+                    frappe.set_route('Form', 'Lead', frm.doc.lead);
+                } else {
+                    frappe.msgprint(__('No Lead is linked to this Design Request.'));
+                }
+            }, __('Create Quotation from Lead')); // Group under "Actions"
+        }
+    },
+
+    type: function(frm) {
+        // Make the 'type' field read-only if its value is 'Mockup Design'
+        if (frm.doc.type === 'Mockup Design') {
+            frm.set_df_property('type', 'read_only', 1);
+        } else {
+            frm.set_df_property('type', 'read_only', 0);
+        }
     }
 });


### PR DESCRIPTION
## Feature description
Cannot able to change type in Design request after save the doctype

## Solution description
In design request doctype ,if doc.type is mockup design and workflow state is sent to customer then type mockup design is set to read only.
## Output
![image](https://github.com/user-attachments/assets/b4ef020e-96be-4de9-b650-ac66f481b442)


## Areas affected and ensured
-Design request doctype
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox