### PR TITLE
feat : Add a button in Quotation and change workflow states 

### DIFF
--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -4,7 +4,7 @@
   "doctype": "Workflow",
   "document_type": "Design Request",
   "is_active": 0,
-  "modified": "2024-12-19 16:04:12.197154",
+  "modified": "2024-12-23 15:44:00.676133",
   "name": "Design Request workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -34,7 +34,7 @@
     "parent": "Design Request workflow",
     "parentfield": "states",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "update_field": null,
     "update_value": null,
     "workflow_builder_id": null
@@ -76,7 +76,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Design Request workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -92,7 +92,7 @@
     "parent": "Design Request workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -104,7 +104,7 @@
     "parent": "Design Request workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -116,7 +116,7 @@
     "parent": "Design Request workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    }
   ],
@@ -129,7 +129,7 @@
   "doctype": "Workflow",
   "document_type": "Quotation",
   "is_active": 1,
-  "modified": "2024-12-20 12:26:08.407074",
+  "modified": "2024-12-23 15:42:01.742560",
   "name": "Quotation Workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -159,7 +159,7 @@
     "parent": "Quotation Workflow",
     "parentfield": "states",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "update_field": null,
     "update_value": null,
     "workflow_builder_id": null
@@ -216,7 +216,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Quotation Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -228,7 +228,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Quotation Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -240,7 +240,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Quotation Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -256,7 +256,7 @@
     "parent": "Quotation Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -268,7 +268,7 @@
     "parent": "Quotation Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -280,7 +280,7 @@
     "parent": "Quotation Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    }
   ],
@@ -292,8 +292,8 @@
   "docstatus": 0,
   "doctype": "Workflow",
   "document_type": "Design Request",
-  "is_active": 0,
-  "modified": "2024-12-20 12:41:19.739558",
+  "is_active": 1,
+  "modified": "2024-12-23 15:28:59.148415",
   "name": "Mockup Workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -368,7 +368,7 @@
     "parent": "Mockup Workflow",
     "parentfield": "states",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "update_field": null,
     "update_value": null,
     "workflow_builder_id": null
@@ -380,7 +380,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -392,7 +392,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -404,7 +404,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -416,7 +416,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -432,7 +432,7 @@
     "parent": "Mockup Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -444,7 +444,7 @@
     "parent": "Mockup Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -456,7 +456,7 @@
     "parent": "Mockup Workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    }
   ],
@@ -469,7 +469,7 @@
   "doctype": "Workflow",
   "document_type": "Feasibility Check",
   "is_active": 1,
-  "modified": "2024-12-13 16:32:06.846241",
+  "modified": "2024-12-23 15:38:34.467880",
   "name": "Feasibility workflow",
   "override_status": 0,
   "send_email_alert": 0,
@@ -499,7 +499,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "states",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "update_field": null,
     "update_value": null,
     "workflow_builder_id": null
@@ -507,7 +507,7 @@
    {
     "allow_edit": "Administrator",
     "avoid_status_override": 0,
-    "doc_status": "0",
+    "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,
@@ -522,7 +522,7 @@
    {
     "allow_edit": "Administrator",
     "avoid_status_override": 0,
-    "doc_status": "0",
+    "doc_status": "1",
     "is_optional_state": 0,
     "message": null,
     "next_action_email_template": null,
@@ -541,7 +541,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -553,7 +553,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -565,7 +565,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -577,7 +577,7 @@
     "allow_self_approval": 1,
     "allowed": "Administrator",
     "condition": null,
-    "next_state": "Send to Customer",
+    "next_state": "Sent to Customer",
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -593,7 +593,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -605,7 +605,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    },
    {
@@ -617,7 +617,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Send to Customer",
+    "state": "Sent to Customer",
     "workflow_builder_id": null
    }
   ],

--- a/versa_system/fixtures/workflow_state.json
+++ b/versa_system/fixtures/workflow_state.json
@@ -39,9 +39,9 @@
   "docstatus": 0,
   "doctype": "Workflow State",
   "icon": "",
-  "modified": "2024-12-13 15:23:08.781248",
-  "name": "Send to Customer",
+  "modified": "2024-12-21 10:03:38.276915",
+  "name": "Sent to Customer",
   "style": "",
-  "workflow_state_name": "Send to Customer"
+  "workflow_state_name": "Sent to Customer"
  }
 ]

--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -250,7 +250,7 @@ fixtures = [
     {
         "dt": "Workflow State",
         "filters": [
-            ["name", "in", ["Draft","Review Request","Approved","Rejected","Send to Customer"]]
+            ["name", "in", ["Draft","Review Request","Approved","Rejected","Sent to Customer"]]
         ]
     },
     {

--- a/versa_system/public/quotation.js
+++ b/versa_system/public/quotation.js
@@ -1,5 +1,6 @@
 frappe.ui.form.on('Quotation', {
     refresh: function(frm) {
+        // Add "Go to Lead" button for Approved Quotations
         if (frm.doc.workflow_state === "Approved") {
             frm.add_custom_button(__('Go to Lead'), function() {
                 if (frm.doc.party_name) {
@@ -7,7 +8,13 @@ frappe.ui.form.on('Quotation', {
                 } else {
                     frappe.msgprint(__('No Lead is linked to the Quotation.'));
                 }
-            })
+            });
         }
+
+        // Add "Go to Final Design" button
+        frm.add_custom_button(__('Go to Final Design'), function() {
+            // Action for the "Go to Final Design" button
+            frappe.set_route('Form', 'Final Design', frm.doc.name);
+        });
     }
 });

--- a/versa_system/versa_system/doctype/design_request/design_request.js
+++ b/versa_system/versa_system/doctype/design_request/design_request.js
@@ -15,5 +15,7 @@ frappe.ui.form.on('Design Request', {
             }
         }, __('Create Quatation from Lead')); // Group under "Actions"
       }
-    }
+
+    },
+
 });

--- a/versa_system/versa_system/doctype/design_request/design_request.js
+++ b/versa_system/versa_system/doctype/design_request/design_request.js
@@ -1,5 +1,3 @@
-// Copyright (c) 2024, efeone and contributors
-// For license information, please see license.txt
 
 frappe.ui.form.on('Design Request', {
     refresh: function(frm) {
@@ -17,5 +15,4 @@ frappe.ui.form.on('Design Request', {
       }
 
     },
-
 });


### PR DESCRIPTION
## Feature description
 Add a button in Quotation and change workflow states 

## Solution description
Added a button in Quotation named as "Go to Final Design".
Changed 4 workflow states from "send to customer" into "sent to customer"
## Output
![image](https://github.com/user-attachments/assets/06d3d736-173d-4d7e-ae73-600197aa51a1)
![image](https://github.com/user-attachments/assets/4484c9c4-218c-4211-9790-103f77a409c3)

![image](https://github.com/user-attachments/assets/b1f43f48-c569-408f-99ea-01214bb90122)


## Areas affected and ensured
-Button "Go to Final Design" in quotation. 
-workflow state
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox