### PR TITLE
feat: Add mapping from Design Request to Raw Material Request with custom button

### DIFF
--- a/versa_system/versa_system/custom_script/material_request.py
+++ b/versa_system/versa_system/custom_script/material_request.py
@@ -1,0 +1,40 @@
+import frappe
+from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
+
+class MaterialRequest(Document):
+    pass
+
+@frappe.whitelist()
+def map_raw_material_to_material_request(source_name, target_doc=None):
+    """
+    Map fields from Raw Material Request to Material Request,
+    including child table 'Item Details' and set qty to 1 in Material Request Item.
+    """
+    def set_missing_values(source, target):
+        # Set the Material Request Type
+        target.material_request_type = "Purchase"
+        target.schedule_date = frappe.utils.nowdate()
+
+    def set_item_defaults(source, target, source_parent):
+        # Set default qty to 1 for each item in the child table
+        target.qty = 1
+
+    target_doc = get_mapped_doc("Raw Material Request", source_name,
+        {
+            "Raw Material Request": {
+                "doctype": "Material Request",
+                "field_map": {
+                    # Map fields if necessary
+                },
+            },
+            "Item Details": {  # Ensure this matches the child table in Raw Material Request
+                "doctype": "Material Request Item",  # Ensure this matches the child table in Material Request
+                "field_map": {
+                    "item": "item_code"
+                },
+                "postprocess": set_item_defaults  # Set qty=1 after mapping
+            }
+        }, target_doc, set_missing_values)
+
+    return target_doc

--- a/versa_system/versa_system/doctype/design_request/design_request.js
+++ b/versa_system/versa_system/doctype/design_request/design_request.js
@@ -14,5 +14,14 @@ frappe.ui.form.on('Design Request', {
         }, __('Create Quatation from Lead')); // Group under "Actions"
       }
 
+      // Add a custom button
+      if (frm.doc.workflow_state === "Approved" && frm.doc.type === "Final Design") {
+        frm.add_custom_button(__('Raw Material Check'), function() {
+          frappe.model.open_mapped_doc({
+            method: "versa_system.versa_system.doctype.raw_material_request.raw_material_request.map_lead_to_raw_material_request",
+            frm: frm,
+          });
+        }, __('Create')); // Group under "Create"
+      }
     },
 });

--- a/versa_system/versa_system/doctype/raw_material_request/raw_material_request.js
+++ b/versa_system/versa_system/doctype/raw_material_request/raw_material_request.js
@@ -1,11 +1,6 @@
 // Copyright (c) 2024, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Raw Material Request", {
-// 	refresh(frm) {
-
-// 	},
-// });
 frappe.ui.form.on('Raw Material Request', {
     refresh: function(frm) {
         // Remove existing buttons to avoid duplicates
@@ -23,7 +18,10 @@ frappe.ui.form.on('Raw Material Request', {
             frm.add_custom_button(
                 __('Raw Material Purchase'),
                 function() {
-                    // Add functionality for "Raw Material Purchase" here
+                  frappe.model.open_mapped_doc({
+                    method: "versa_system.versa_system.custom_script.material_request.map_raw_material_to_material_request",
+                    frm: frm
+                  });
                 }
             );
         }
@@ -35,6 +33,7 @@ frappe.ui.form.on('Raw Material Request', {
                 function() {
                     // Add redirection logic to Quotation form here
                     frappe.set_route('List', 'Quotation');
+
                 }
             );
         }

--- a/versa_system/versa_system/doctype/raw_material_request/raw_material_request.py
+++ b/versa_system/versa_system/doctype/raw_material_request/raw_material_request.py
@@ -1,9 +1,47 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
+
 
 
 class RawMaterialRequest(Document):
 	pass
+
+@frappe.whitelist()
+def map_lead_to_raw_material_request(source_name, target_doc=None):
+    """
+    Map fields from Design Request DocType to Raw Material Request DocType,
+    including child table 'Item Details'
+    """
+    def set_missing_values(source, target):
+        # Any additional field setup
+        pass
+
+    target_doc = get_mapped_doc(
+        "Design Request", source_name,
+        {
+            "Design Request": {
+                "doctype": "Raw Material Request",  # Fixed extra space in DocType name
+                "field_map": {},
+            },
+            "Item Details": {  # Ensure this matches the child table in Design Request
+                "doctype": "Item Details",  # Ensure this matches the child table in Raw Material Request
+                "field_map": {
+                    "item": "item",
+                    "material": "material",
+                    "brand": "brand",
+                    "model": "model",
+                    "rate_range": "rate_range",
+                    "size": "size",
+                    "design": "design",
+                }
+            }
+        },
+        target_doc,
+        set_missing_values
+    )
+
+    return target_doc


### PR DESCRIPTION
## Feature description
Add a mapping from Design Request to Raw Material Request with a custom button

## Solution description
* Added a custom button labeled "Raw Material Check" in the Design Request form when:workflow_state is "Approved",type is       "Final Design"
*Implemented map_lead_to_raw_material_request function to map fields from Design Request to Raw Material Request, including child table "Item Details".
*Fixed formatting and removed extra spaces in DocType names.

## Output
![image](https://github.com/user-attachments/assets/08be2963-c7ce-48e3-9ad6-66ba0aa9bdf6)
![image](https://github.com/user-attachments/assets/df717737-fcb4-4df0-a769-59fbd92c74b5)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox