### PR TITLE
feat: mapping from quotation to final design and edit design request doctype.

### DIFF
--- a/versa_system/public/quotation.js
+++ b/versa_system/public/quotation.js
@@ -2,6 +2,7 @@ frappe.ui.form.on('Quotation', {
     refresh: function(frm) {
         // Add "Go to Lead" button for Approved Quotations
         if (frm.doc.workflow_state === "Approved") {
+            // Button to navigate to Lead
             frm.add_custom_button(__('Go to Lead'), function() {
                 if (frm.doc.party_name) {
                     frappe.set_route('Form', 'Lead', frm.doc.party_name);
@@ -9,12 +10,14 @@ frappe.ui.form.on('Quotation', {
                     frappe.msgprint(__('No Lead is linked to the Quotation.'));
                 }
             });
-        }
 
-        // Add "Go to Final Design" button
-        frm.add_custom_button(__('Go to Final Design'), function() {
-            // Action for the "Go to Final Design" button
-            frappe.set_route('Form', 'Final Design', frm.doc.name);
-        });
+            // Add "Go to Final Design" button for Approved Quotations
+            frm.add_custom_button(__('Go to Final Design'), function() {
+                frappe.model.open_mapped_doc({
+                    method: "versa_system.versa_system.doctype.design_request.design_request.map_quotation_to_design_request",
+                    frm: frm,
+                });
+            }, __("Create"));
+        }
     }
 });

--- a/versa_system/versa_system/doctype/design_request/design_request.json
+++ b/versa_system/versa_system/doctype/design_request/design_request.json
@@ -51,7 +51,8 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "Mockup Design\nFinal Design"
+   "options": "Mockup Design\nFinal Design",
+   "set_only_once": 1
   },
   {
    "depends_on": "eval: doc.type == 'Final Design'\n",
@@ -63,7 +64,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-21 11:51:30.057312",
+ "modified": "2024-12-27 13:29:47.531744",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Design Request",

--- a/versa_system/versa_system/doctype/design_request/design_request.py
+++ b/versa_system/versa_system/doctype/design_request/design_request.py
@@ -73,6 +73,44 @@ def map_lead_to_design_request(source_name, target_doc=None):
 
     return target_doc
 
+@frappe.whitelist()
+def map_quotation_to_design_request(source_name, target_doc=None):
+    """
+    Map fields from Quotation DocType to Design Request DocType,
+    including specified fields like 'lead', 'customer_name', and mapping 'item_code' to 'item' in Item Details.
+    """
+    def set_missing_values(source, target):
+        # Set any missing values if needed
+        target.type = "Final Design"
+
+    # Get the mapped document
+    target_doc = get_mapped_doc(
+        "Quotation",
+        source_name,
+        {
+            "Quotation": {
+                "doctype": "Design Request",
+                "field_map": {
+                    "party_name": "lead",  # Map 'party_name' to 'lead'
+                    "customer_name": "first_name",  # Map 'customer_name' to 'first_name'
+                },
+            },
+            "Quotation Item": {  # Mapping item_code from Quotation to item in Item Details of Design Request
+                "doctype": "Item Details",  # Target table in Design Request
+                "field_map": {
+                    "item_code": "item",  # Map 'item_code' from Quotation to 'item' in Item Details
+                },
+            },
+        },
+        target_doc,
+        set_missing_values
+    )
+
+    return target_doc
+
+
+
+
 #Function to dynamically activate one workflow and deactivate another
 def set_workflow(doc, method):
     if doc.type == "Mockup Design":


### PR DESCRIPTION
## Feature description
Mapping from quotation to final design when quotation is approved and edit design request doctype (set only once)

## Solution description
Edited design request doctype (enable set only once).
Added a button 'go to final design' in quotation , mapped that button into final design and it shows only when the quotation 
is approved.
## Output
![image](https://github.com/user-attachments/assets/22c59c73-1874-438e-90ac-3c1adf45cabe)


## Areas affected and ensured
-New feature ( Quotation, Design Request)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox