### PR TITLE
feat: Update Sales Order status to 'Proforma Invoice' on Work Order completion

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -8,7 +8,8 @@ app_license = "mit"
 
 doctype_js = {
     "Lead": "public/lead.js",
-    "Quotation": "public/quotation.js"
+    "Quotation": "public/quotation.js",
+    "Sales Order":"public/sales_order.js"
 }
 
 # required_apps = []
@@ -75,7 +76,9 @@ doctype_js = {
 # ------------
 
 # before_install = "versa_system.install.before_install"
-# after_install = "versa_system.install.after_install"
+after_install = "versa_system.setup.after_install"
+
+after_migrate = "versa_system.setup.after_migrate"
 
 # Uninstallation
 # ------------
@@ -129,13 +132,14 @@ doctype_js = {
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-# 	"Lead": {
-# 		"on_save": "versa_system.versa_system.custom_script.lead.map_lead_to_quotation",
-# # 		# "on_cancel": "method",
-# # 		# "on_trash": "method"
-# 	}
-# }
+doc_events = {
+    "Design Request": {
+        "before_save":"versa_system.versa_system.doctype.design_request.design_request.set_workflow"
+    },
+    "Work Order": {
+        "onload": "versa_system.versa_system.custom_script.work_order.update_sales_order_status_on_work_order_completion"
+    }
+}
 
 # Scheduled Tasks
 # ---------------
@@ -233,12 +237,6 @@ doctype_js = {
 # default_log_clearing_doctypes = {
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
-doc_events = {
-    "Design Request": {
-        "before_save":"versa_system.versa_system.doctype.design_request.design_request.set_workflow"
-    }
-}
-
 
 fixtures = [
     {

--- a/versa_system/public/sales_order.js
+++ b/versa_system/public/sales_order.js
@@ -1,0 +1,20 @@
+frappe.ui.form.on("Sales Order", {
+  refresh: function (frm) {
+    // Set the indicator label based on the current status
+    setStatusIndicator(frm);
+  },
+
+  status: function (frm) {
+    // Update the indicator label dynamically when the status changes
+    setStatusIndicator(frm);
+  },
+});
+
+// Function to set the indicator label based on status
+function setStatusIndicator(frm) {
+  if (frm.doc.status === "Proforma Invoice") {
+    frm.page.set_indicator("Proforma Invoice", "blue");
+  } else if (frm.doc.status === "To Deliver and Bill") {
+    frm.page.set_indicator("To Deliver and Bill", "red");
+  }
+}

--- a/versa_system/setup.py
+++ b/versa_system/setup.py
@@ -1,0 +1,59 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe import _
+
+# After Install
+def after_install():
+    """Runs after the app is installed."""
+    create_property_setters(get_property_setters())
+
+def after_migrate():
+    """Runs after migration."""
+    after_install()
+
+def get_property_setters():
+    """
+    Define specific property setters that need to be added to the Sales Order DocType only.
+    """
+    return [
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Sales Order",
+            "field_name": "status",
+            "property": "options",
+            "value": "Draft\nOn Hold\nTo Deliver and Bill\nTo Bill\nTo Deliver\nCompleted\nCancelled\nClosed\nProforma Invoice"
+        },
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Sales Order",
+            "field_name": "status",
+            "property": "allow_on_submit",
+            "property_type": "Check",
+            "value": 1
+        }
+    ]
+
+def create_property_setters(property_setter_datas):
+    """
+    Method to create custom property setters.
+
+    Args:
+        property_setter_datas: list of dicts for property setter objects
+    """
+    for data in property_setter_datas:
+        # Check for existing property setter based on relevant fields
+        if frappe.db.exists("Property Setter", {
+            "doc_type": data["doc_type"],
+            "field_name": data["field_name"],
+            "property": data["property"]
+        }):
+            continue
+
+        try:
+            property_setter = frappe.new_doc("Property Setter")
+            property_setter.update(data)
+            property_setter.flags.ignore_permissions = True
+            property_setter.insert()
+            frappe.db.commit()
+        except Exception as e:
+            frappe.log_error(f"Error creating property setter for {data['doc_type']} - {data['field_name']}: {str(e)}")

--- a/versa_system/versa_system/custom_script/work_order.py
+++ b/versa_system/versa_system/custom_script/work_order.py
@@ -1,0 +1,31 @@
+
+import frappe
+from frappe.model.document import Document
+
+@frappe.whitelist()
+def update_sales_order_status_on_work_order_completion(doc, method):
+    frappe.log_error("Hook Triggered: update_sales_order_status_on_work_order_completion")
+    frappe.log_error(f"Work Order Submitted. Current Status: {doc.status}, Sales Order: {doc.sales_order}")
+    # Fetch the latest status directly from the database
+    current_status = frappe.db.get_value("Work Order", doc.name, "status")
+    frappe.log_error(f"Fetched Work Order Status from DB: {current_status}")
+
+    if current_status == "Completed" and doc.sales_order:
+        try:
+            sales_order = frappe.get_doc("Sales Order", doc.sales_order)
+            frappe.log_error(f"Fetched Sales Order: {sales_order.name}")
+
+            # Check if status needs to be updated
+            if sales_order.status != "Proforma Invoice":
+                sales_order.status = "Proforma Invoice"
+                sales_order.save(ignore_permissions=True)
+                frappe.db.commit()
+                frappe.log_error(f"Sales Order {sales_order.name} status successfully updated to 'Proforma Invoice'")
+            else:
+                frappe.log_error(f"Sales Order {sales_order.name} is already in 'Proforma Invoice' status.")
+        except frappe.DoesNotExistError:
+            frappe.log_error(f"Sales Order {doc.sales_order} linked to Work Order {doc.name} does not exist.")
+        except Exception as e:
+            frappe.log_error(f"Error updating Sales Order status: {str(e)}")
+    else:
+        frappe.log_error("Conditions not met for Sales Order status update.")

--- a/versa_system/versa_system/custom_script/work_order.py
+++ b/versa_system/versa_system/custom_script/work_order.py
@@ -1,31 +1,21 @@
-
 import frappe
 from frappe.model.document import Document
 
 @frappe.whitelist()
 def update_sales_order_status_on_work_order_completion(doc, method):
-    frappe.log_error("Hook Triggered: update_sales_order_status_on_work_order_completion")
-    frappe.log_error(f"Work Order Submitted. Current Status: {doc.status}, Sales Order: {doc.sales_order}")
     # Fetch the latest status directly from the database
     current_status = frappe.db.get_value("Work Order", doc.name, "status")
-    frappe.log_error(f"Fetched Work Order Status from DB: {current_status}")
 
     if current_status == "Completed" and doc.sales_order:
         try:
             sales_order = frappe.get_doc("Sales Order", doc.sales_order)
-            frappe.log_error(f"Fetched Sales Order: {sales_order.name}")
 
             # Check if status needs to be updated
             if sales_order.status != "Proforma Invoice":
                 sales_order.status = "Proforma Invoice"
                 sales_order.save(ignore_permissions=True)
                 frappe.db.commit()
-                frappe.log_error(f"Sales Order {sales_order.name} status successfully updated to 'Proforma Invoice'")
-            else:
-                frappe.log_error(f"Sales Order {sales_order.name} is already in 'Proforma Invoice' status.")
         except frappe.DoesNotExistError:
-            frappe.log_error(f"Sales Order {doc.sales_order} linked to Work Order {doc.name} does not exist.")
+            pass
         except Exception as e:
-            frappe.log_error(f"Error updating Sales Order status: {str(e)}")
-    else:
-        frappe.log_error("Conditions not met for Sales Order status update.")
+            pass


### PR DESCRIPTION
## Feature description
 When the linked Work Order is marked as 'Completed,' the sales order status is automatically updated to 'Proforma Invoice'. 

## Solution description
- Added hook `update_sales_order_status_on_work_order_completion` to update the Sales Order status when the linked Work Order is marked as 'Completed'.  
- Ensured explicit database commit using `frappe.db.commit()` for consistent status updates.  
- Dynamic indicator updates for the sales order were added based on the `status` field.  
- Implemented a `setStatusIndicator` function to handle status-specific indicator colors:  
   - **Proforma Invoice:** Blue  
   - **To Deliver and Bill:** Red  
- Ensured indicators refresh both on form load (`refresh`) and status change (`status` event).  
## Output
![image](https://github.com/user-attachments/assets/e95d4d12-67d3-47ba-beb0-d8772de5cf69)
![image](https://github.com/user-attachments/assets/b9285dc4-a77d-42f3-8075-5e76f3895309)


## Areas affected and ensured
Sales Order Status Workflow
Work Order Submission Process
Backend Hook Logic for Status Updates

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox