### PR TITLE
feat:Add custom field 'item_details' to Quotation

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -75,7 +75,7 @@ doctype_js = {
 # Installation
 # ------------
 
-# before_install = "versa_system.install.before_install"
+before_install = "versa_system.install.before_install"
 after_install = "versa_system.setup.after_install"
 
 after_migrate = "versa_system.setup.after_migrate"

--- a/versa_system/setup.py
+++ b/versa_system/setup.py
@@ -6,10 +6,14 @@ from frappe import _
 def after_install():
     """Runs after the app is installed."""
     create_property_setters(get_property_setters())
+    create_custom_fields(get_quotion_custom_fields(), ignore_validate=True)
 
 def after_migrate():
     """Runs after migration."""
     after_install()
+
+def before_uninstall():
+    delete_custom_fields(get_quotion_custom_fields())
 
 def get_property_setters():
     """
@@ -57,3 +61,20 @@ def create_property_setters(property_setter_datas):
             frappe.db.commit()
         except Exception as e:
             frappe.log_error(f"Error creating property setter for {data['doc_type']} - {data['field_name']}: {str(e)}")
+
+
+def get_quotion_custom_fields():
+    '''
+        Custom fields that need to be added to the Student Group DocType
+    '''
+    return {
+        "Quotation": [
+            {
+                "fieldname": "item_details",
+                "fieldtype": "Table",
+                "label": "item Details",
+                "insert_after": "scan_barcode",
+                "options":"Item Details"
+            }
+        ]
+    }


### PR DESCRIPTION
## Feature description
Add custom field 'item_details' to Quotation and setup hooks for installation lifecycle

## Solution description
- Enabled the `before_install` hook in `hooks.py` for pre-installation setup.  
- Added `create_custom_fields` for Quotation in `after_install`.  
- Implemented the `before_uninstall` hook to clean up custom fields.  
- Defined `get_quotion_custom_fields` to add a table field `item_details` in Quotation.  
- Improved migration process by invoking `after_install` during `after_migrate`.  
## Output
![image](https://github.com/user-attachments/assets/30fbd7eb-66a2-4792-9d61-5a2d3e979306)


## Areas affected and ensured
-hooks.py (enabled before_install)
-setup.py (added item_details field, lifecycle methods for install/uninstall)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox