### PR TITLE
feat: Add validation for feasibility (one lead can create one feasibility)

### DIFF
--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -481,7 +481,7 @@
   "doctype": "Workflow",
   "document_type": "Feasibility Check",
   "is_active": 1,
-  "modified": "2025-01-09 11:51:49.118864",
+  "modified": "2025-01-10 11:21:17.250888",
   "name": "Feasibility workflow",
   "override_status": 0,
   "send_email_alert": 0,

--- a/versa_system/public/lead.js
+++ b/versa_system/public/lead.js
@@ -21,13 +21,32 @@ frappe.ui.form.on('Lead', {
         frm.add_custom_button(
             __("Feasibility Check"),
             function () {
-                frappe.model.open_mapped_doc({
-                    method: "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_lead_to_feasibility_check",
-                    frm: frm,
+                frappe.call({
+                    method: "frappe.client.get_list",
+                    args: {
+                        doctype: "Feasibility Check",
+                        filters: { lead: frm.doc.name },
+                        fields: ["name"]
+                    },
+                    callback: function (response) {
+                        if (response.message && response.message.length > 0) {
+                            frappe.msgprint({
+                                title: __("Message"),
+                                indicator: "red",
+                                message: `A feasibility check already exists for this lead: ${frm.doc.name}.`
+                            });
+                        } else {
+                            frappe.model.open_mapped_doc({
+                                method: "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_lead_to_feasibility_check",
+                                frm: frm,
+                            });
+                        }
+                    }
                 });
             },
             __("Create")
         );
+
 
                 frm.add_custom_button(
                     __("Go to Final Design"),

--- a/versa_system/public/lead.js
+++ b/versa_system/public/lead.js
@@ -21,32 +21,13 @@ frappe.ui.form.on('Lead', {
         frm.add_custom_button(
             __("Feasibility Check"),
             function () {
-                frappe.call({
-                    method: "frappe.client.get_list",
-                    args: {
-                        doctype: "Feasibility Check",
-                        filters: { lead: frm.doc.name },
-                        fields: ["name"]
-                    },
-                    callback: function (response) {
-                        if (response.message && response.message.length > 0) {
-                            frappe.msgprint({
-                                title: __("Message"),
-                                indicator: "red",
-                                message: `A feasibility check already exists for this lead: ${frm.doc.name}.`
-                            });
-                        } else {
-                            frappe.model.open_mapped_doc({
-                                method: "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_lead_to_feasibility_check",
-                                frm: frm,
-                            });
-                        }
-                    }
+                frappe.model.open_mapped_doc({
+                    method: "versa_system.versa_system.doctype.feasibility_check.feasibility_check.map_lead_to_feasibility_check",
+                    frm: frm,
                 });
             },
             __("Create")
         );
-
 
                 frm.add_custom_button(
                     __("Go to Final Design"),

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -11,6 +11,14 @@ def map_lead_to_feasibility_check(source_name, target_doc=None):
     Map fields from Lead DocType to Feasibility Check DocType,
     including child table 'Enquiry Details'
     """
+    existing_feasibility = frappe.get_all(
+        'Feasibility Check',
+        filters={'lead': source_name},
+        fields=['name']
+    )
+
+    if existing_feasibility:
+        frappe.throw(f"A feasibility check already exists for this lead (Lead: {source_name}).")
     def set_missing_values(source, target):
         # Set any missing values if needed
         pass

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -1,4 +1,3 @@
-
 import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
@@ -11,14 +10,24 @@ def map_lead_to_feasibility_check(source_name, target_doc=None):
     Map fields from Lead DocType to Feasibility Check DocType,
     including child table 'Enquiry Details'
     """
-    existing_feasibility = frappe.get_all(
-        'Feasibility Check',
-        filters={'lead': source_name},
-        fields=['name']
+    # Validate if a feasibility check already exists for this lead
+    existing_feasibility = frappe.db.exists(
+        "Feasibility Check",
+        {
+            "lead": source_name,
+            "docstatus": ["<", 2],
+            "workflow_state": ["!=", "Rejected"]
+        }
     )
 
     if existing_feasibility:
-        frappe.throw(f"A feasibility check already exists for this lead (Lead: {source_name}).")
+        frappe.msgprint(
+            f"A feasibility check already exists for this lead (Lead: {source_name}).",
+            title="Notification",
+            indicator="red"
+        )
+        return None  
+
     def set_missing_values(source, target):
         # Set any missing values if needed
         pass


### PR DESCRIPTION
## Feature description
 Add validation for feasibility (one lead can create one feasibility)

## Solution description
Added validation for feasibility ( one lead can create one feasibility)
## Output
![image](https://github.com/user-attachments/assets/74e372ec-1200-48ff-a0c4-0d1091eac8c1)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox