### PR TITLE
fix:Add custom button 'Go to Quotation' to Raw Material Request form

### DIFF
--- a/versa_system/versa_system/custom_script/quotation.py
+++ b/versa_system/versa_system/custom_script/quotation.py
@@ -73,3 +73,17 @@ def map_lead_to_quotation(source_name, target_doc=None):
     )
 
     return target_doc
+
+@frappe.whitelist()
+def get_quotations_by_lead(lead_name):
+    """
+    Function to fetch all Quotations associated with a specific Lead.
+    This method is intended to be called from the client side via an API call
+    """
+    if not lead_name:
+        frappe.throw(_("Lead name is required"))
+    return frappe.get_all(
+        "Quotation",
+        filters={"party_name": lead_name},  # Use the correct field here
+        fields=["name"]
+    )

--- a/versa_system/versa_system/doctype/raw_material_request/raw_material_request.js
+++ b/versa_system/versa_system/doctype/raw_material_request/raw_material_request.js
@@ -20,34 +20,33 @@ frappe.ui.form.on('Raw Material Request', {
                 }
             );
         }
-
-        // Add "Go to Quotation" button if all rows are checked
-        if (all_checked) {
-            frm.add_custom_button(
-                __('Go to Quotation'),
-                function() {
-                    frappe.call({
-                        method: "frappe.client.get_list",
-                        args: {
-                            doctype: "Quotation",
-                            fields: ["name"]
-                        },
-                        callback: function(response) {
-                            if (response.message && response.message.length > 0) {
-                                // Navigate to the existing Quotation
-                                frappe.set_route('Form', 'Quotation', response.message[0].name);
-                            } else {
-                                // Create and navigate to a new Quotation
-                                frappe.new_doc('Quotation');
-                            }
-                        }
-                    });
+        // Add a custom button labeled 'Go to Quotation' in the form
+        if (all_checked){
+        frm.add_custom_button(__('Go to Quotation'), function() {
+            if (!frm.doc.lead) {
+                frappe.msgprint(__('No Lead is linked to this Raw Material Request.'));
+                return;
+            }
+            frappe.call({
+                method: "versa_system.versa_system.custom_script.quotation.get_quotations_by_lead",
+                args: {
+                    lead_name: frm.doc.lead
+                },
+                callback: function(response) {
+                    if (response.message && response.message.length > 0) {
+                        frappe.set_route("Form", "Quotation", response.message[0].name);
+                    } else {
+                        frappe.msgprint(__('No Quotation is linked to the Lead associated with this Raw Material Request.'));
+                    }
                 }
-            );
-        }
+            });
+        });
+      }
+
         if (frm.fields_dict['item_details']) {
-              frm.fields_dict['item_details'].grid.toggle_display('is_customized', false);
-              frm.fields_dict['item_details'].grid.toggle_display('is_feasible', false);
+              frm.fields_dict['item_details'].grid.toggle_display('is_customized', false);  // Hide the 'is_customized' column in the child table
+              frm.fields_dict['item_details'].grid.toggle_display('is_feasible', false);   // Hide the 'is_feasible' column in the child table
+
         }
     }
 });


### PR DESCRIPTION
## Feature description
Add custom button 'Go to Quotation' to Raw Material Request form

## Solution description
- Add a button allowing users to navigate to the associated Quotation from the Raw Material Request form.
- Validates if a Lead is linked to the Raw Material Request; if not, displays a message.
- Calls the server-side method to fetch Quotations linked to the Lead.
- Navigates to the existing Quotation if found, or shows a message if no Quotation is associated with the Lead.
## Output

![image](https://github.com/user-attachments/assets/e05c67e8-d54f-4232-beb5-e45a990ea9de)
![image](https://github.com/user-attachments/assets/3f8a7ba2-f011-4742-8253-16a1e3363fda)

## Areas affected and ensured
Areas Affected:
- Raw Material Request (RMR) Form: A custom button 'Go to Quotation' has been added to the form.
- Quotation: Ensures that the Quotation linked to the Lead can be accessed from the Raw Material Request.
- Lead: The Lead field's relationship with Raw Material Request and Quotation is leveraged to fetch relevant data.

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox