### PR TITLE
fix: change naming series of feasibility check doctype and edit feasibility check workflow

### DIFF
--- a/versa_system/fixtures/workflow.json
+++ b/versa_system/fixtures/workflow.json
@@ -4,13 +4,13 @@
   "doctype": "Workflow",
   "document_type": "Design Request",
   "is_active": 0,
-  "modified": "2025-01-07 16:31:38.969064",
+  "modified": "2025-01-09 12:21:39.459668",
   "name": "Design Request workflow",
   "override_status": 0,
   "send_email_alert": 0,
   "states": [
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -25,7 +25,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -74,7 +74,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Design Request workflow",
@@ -129,13 +129,13 @@
   "doctype": "Workflow",
   "document_type": "Quotation",
   "is_active": 1,
-  "modified": "2025-01-08 10:11:56.828411",
+  "modified": "2025-01-10 12:54:32.544262",
   "name": "Quotation Workflow",
   "override_status": 0,
   "send_email_alert": 0,
   "states": [
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -150,7 +150,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -214,7 +214,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Quotation Workflow",
@@ -226,7 +226,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Quotation Workflow",
@@ -238,7 +238,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Quotation Workflow",
@@ -250,7 +250,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Quotation Workflow",
@@ -304,14 +304,14 @@
   "docstatus": 0,
   "doctype": "Workflow",
   "document_type": "Design Request",
-  "is_active": 1,
-  "modified": "2025-01-08 10:03:34.771967",
+  "is_active": 0,
+  "modified": "2025-01-13 10:47:48.496215",
   "name": "Mockup Workflow",
   "override_status": 0,
   "send_email_alert": 0,
   "states": [
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -371,7 +371,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -390,7 +390,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
@@ -402,7 +402,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
@@ -414,7 +414,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
@@ -426,19 +426,7 @@
    {
     "action": "Send to Customer",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
-    "condition": null,
-    "next_state": "Sent to Customer",
-    "parent": "Mockup Workflow",
-    "parentfield": "transitions",
-    "parenttype": "Workflow",
-    "state": "Draft",
-    "workflow_builder_id": null
-   },
-   {
-    "action": "Send to Customer",
-    "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
     "next_state": "Sent to Customer",
     "parent": "Mockup Workflow",
@@ -493,13 +481,13 @@
   "doctype": "Workflow",
   "document_type": "Feasibility Check",
   "is_active": 1,
-  "modified": "2025-01-07 17:27:54.678117",
+  "modified": "2025-01-13 15:52:41.566527",
   "name": "Feasibility workflow",
   "override_status": 0,
   "send_email_alert": 0,
   "states": [
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -514,7 +502,7 @@
     "workflow_builder_id": null
    },
    {
-    "allow_edit": "Administrator",
+    "allow_edit": "Lead User",
     "avoid_status_override": 0,
     "doc_status": "0",
     "is_optional_state": 0,
@@ -523,7 +511,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "states",
     "parenttype": "Workflow",
-    "state": "Sent to Customer",
+    "state": "Sent to Feasibility Analyst",
     "update_field": null,
     "update_value": null,
     "workflow_builder_id": null
@@ -561,11 +549,11 @@
   ],
   "transitions": [
    {
-    "action": "Send to Customer",
+    "action": "Send to Feasibility Analyst",
     "allow_self_approval": 1,
-    "allowed": "Administrator",
+    "allowed": "Lead User",
     "condition": null,
-    "next_state": "Sent to Customer",
+    "next_state": "Sent to Feasibility Analyst",
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
@@ -581,7 +569,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Sent to Customer",
+    "state": "Sent to Feasibility Analyst",
     "workflow_builder_id": null
    },
    {
@@ -593,7 +581,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Sent to Customer",
+    "state": "Sent to Feasibility Analyst",
     "workflow_builder_id": null
    },
    {
@@ -605,7 +593,7 @@
     "parent": "Feasibility workflow",
     "parentfield": "transitions",
     "parenttype": "Workflow",
-    "state": "Sent to Customer",
+    "state": "Sent to Feasibility Analyst",
     "workflow_builder_id": null
    }
   ],

--- a/versa_system/fixtures/workflow_action_master.json
+++ b/versa_system/fixtures/workflow_action_master.json
@@ -26,5 +26,12 @@
   "modified": "2024-12-13 15:29:39.126493",
   "name": "Send to Customer",
   "workflow_action_name": "Send to Customer"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow Action Master",
+  "modified": "2025-01-13 15:41:16.165025",
+  "name": "Send to Feasibility Analyst",
+  "workflow_action_name": "Send to Feasibility Analyst"
  }
 ]

--- a/versa_system/fixtures/workflow_state.json
+++ b/versa_system/fixtures/workflow_state.json
@@ -11,6 +11,15 @@
  {
   "docstatus": 0,
   "doctype": "Workflow State",
+  "icon": "",
+  "modified": "2025-01-13 15:39:50.784815",
+  "name": "Sent to Feasibility Analyst",
+  "style": "",
+  "workflow_state_name": "Sent to Feasibility Analyst"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Workflow State",
   "icon": "remove",
   "modified": "2024-12-11 14:07:09.410613",
   "name": "Rejected",

--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -248,13 +248,13 @@ fixtures = [
     {
         "dt": "Workflow State",
         "filters": [
-            ["name", "in", ["Draft","Review Request","Approved","Rejected","Sent to Customer"]]
+            ["name", "in", ["Draft","Review Request","Approved","Rejected","Sent to Customer","Sent to Feasibility Analyst"]]
         ]
     },
     {
         "dt": "Workflow Action Master",
         "filters": [
-            ["name", "in", ["Approve", "Reject", "Review Request","Send to Customer"]]
+            ["name", "in", ["Approve", "Reject", "Review Request","Send to Customer","Send to Feasibility Analyst"]]
         ]
     }
 ]

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "Feas.#####",
+ "autoname": "format:FC-{YYYY}-{#####}",
  "creation": "2024-12-07 16:11:46.809290",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -55,11 +55,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-13 13:27:59.468820",
+ "modified": "2025-01-13 15:06:39.116582",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Check",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
## Feature description
Need to edit naming series of feasibility check doctype.
Need to edit feasibility check workflow.

## Solution description
Changed naming series of feasibility check doctype.
Edited feasibility workflow( state, action, next state and allowed sections)
## Output
![image](https://github.com/user-attachments/assets/9a804094-596e-4844-8a96-159e11ae2225)
![image](https://github.com/user-attachments/assets/7108c530-acac-48e3-aca6-d4d51ba1e5f9)
![image](https://github.com/user-attachments/assets/bb6654b3-f7ce-4c32-8909-8481e276156e)


## Areas affected and ensured
-Edit feature (naming series and workflow)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefox