### PR TITLE
Add Profoma Invoice status through setup.py file

### DIFF
--- a/versa_system/hooks.py
+++ b/versa_system/hooks.py
@@ -33,7 +33,7 @@ doctype_js = {
     "Lead": "public/js/lead.js",
     "Quotation":"public/js/quotation.js",
     "Feasibility Check": "public/js/moc_design.js",
-    "sales_order":"public/js/sales_order.js"
+    "Sales Order": "public/js/sales_order.js"
 
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}

--- a/versa_system/public/js/sales_order.js
+++ b/versa_system/public/js/sales_order.js
@@ -1,22 +1,20 @@
-
 frappe.ui.form.on("Sales Order", {
-    refresh: function (frm) {
-      // Set the indicator label based on the current status
-      setStatusIndicator(frm);
-    },
-  
-    status: function (frm) {
-      // Update the indicator label dynamically when the status changes
-      setStatusIndicator(frm);
-    },
-  });
-  
-  // Function to set the indicator label based on status
-  function setStatusIndicator(frm) {
-    if (frm.doc.status === "Proforma Invoice") {
-      frm.page.set_indicator("Proforma Invoice", "blue");
-    } else if (frm.doc.status === "To Deliver and Bill") {
-      frm.page.set_indicator("To Deliver and Bill", "red");
-    }
+  refresh: function (frm) {
+    // Set the indicator label based on the current status
+    setStatusIndicator(frm);
+  },
+
+  status: function (frm) {
+    // Update the indicator label dynamically when the status changes
+    setStatusIndicator(frm);
+  },
+});
+
+// Function to set the indicator label based on status
+function setStatusIndicator(frm) {
+  if (frm.doc.status === "Proforma Invoice") {
+    frm.page.set_indicator("Proforma Invoice", "blue");
+  } else if (frm.doc.status === "To Deliver and Bill") {
+    frm.page.set_indicator("To Deliver and Bill", "red");
   }
-   
+}

--- a/versa_system/setup.py
+++ b/versa_system/setup.py
@@ -1,8 +1,8 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe import _
-   
-    
+
+# After Install
 def after_install():
     """Runs after the app is installed."""
     create_property_setters(get_property_setters())
@@ -23,7 +23,14 @@ def get_property_setters():
             "property": "options",
             "value": "Draft\nOn Hold\nTo Deliver and Bill\nTo Bill\nTo Deliver\nCompleted\nCancelled\nClosed\nProforma Invoice"
         },
-         
+        {
+            "doctype_or_field": "DocField",
+            "doc_type": "Sales Order",
+            "field_name": "status",
+            "property": "allow_on_submit",
+            "property_type": "Check",
+            "value": 1
+        }
     ]
 
 def create_property_setters(property_setter_datas):

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -16,21 +16,7 @@ frappe.ui.form.on("Feasibility Check", {
         }
     },
 });
-// frappe.ui.form.on("Feasibility Check", {
-//     refresh(frm) {
-//         if (frm.doc.workflow_state === "Approved" ) {  
-//             frm.add_custom_button(
-//                 __("GoTo MOC Design"),
-//                 function () {
-//                     frappe.model.open_mapped_doc({
-//                         method: "versa_system.versa_system.doctype.moc_design.moc_design.map_feasibility_check_to_moc_design",
-//                         source_name: frm.doc.name
-//                     });
-//                 }
-//             );
-//         }
-//     }
-// });
+
 
 
 

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Feasibility Check", {
     refresh(frm) {
-        if (!frm.is_new()) { // Ensure the button appears only after saving
+        if (frm.doc.workflow_state === "Approved") { // Ensure the button appears only after saving
             frm.add_custom_button(
                 __("GoTo MOC Design"),
                 function () {
@@ -16,6 +16,22 @@ frappe.ui.form.on("Feasibility Check", {
         }
     },
 });
+// frappe.ui.form.on("Feasibility Check", {
+//     refresh(frm) {
+//         if (frm.doc.workflow_state === "Approved" ) {  
+//             frm.add_custom_button(
+//                 __("GoTo MOC Design"),
+//                 function () {
+//                     frappe.model.open_mapped_doc({
+//                         method: "versa_system.versa_system.doctype.moc_design.moc_design.map_feasibility_check_to_moc_design",
+//                         source_name: frm.doc.name
+//                     });
+//                 }
+//             );
+//         }
+//     }
+// });
+
 
 
 

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "LD.####",
+ "autoname": "format:FC-{YY}-{#####}",
  "creation": "2025-02-18 22:54:33.356673",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -25,11 +25,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-20 03:24:46.517252",
+ "modified": "2025-02-28 02:44:35.596369",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Feasibility Check",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -1,98 +1,98 @@
-# # # # Copyright (c) 2025, efeone and contributors
-# # #  # For license information, please see license.txt
-
-# import frappe
-# from frappe.model.document import Document
-# from frappe.model.mapper import get_mapped_doc
-
-# class FeasibilityCheck(Document):
-#     pass
-
-# @frappe.whitelist()
-# def map_lead_to_feasibility_check(source_name, target_doc=None):
-#     """
-#     Map fields from Lead Doctype to Feasibility Check Doctype,
-#     including child table 'Material Details' -> 'Feasible Material Details'
-#     """
-#     def set_missing_values(source,target):
-#         pass
-
-#     target_doc = get_mapped_doc("Lead", source_name,
-#         {
-#             "Lead": {
-#                 "doctype": "Feasibility Check",
-#                 "field_map": {}
-#             },
-#             "Lead Material Details": { 
-#                 "doctype": "Lead Material Details",  
-#                 "field_map": {
-#                     "material_type": "material_type",
-#                     "size": "size",
-#                     "brand": "brand",
-#                     "rate_range": "rate_range",
-#                     "image": "image",
-#                     "feasible": "feasible",
-#                     "quantity": "quantity"
-#                 },
-#                 "add_if_empty": True  
-#             }
-#         }, target_doc, set_missing_values)
-
-#     return target_doc
+ # Copyright (c) 2025, efeone and contributors
+ # For license information, please see license.txt
 
 import frappe
 from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
 
 class FeasibilityCheck(Document):
-    def before_save(self):
-        if self.lead:
-            self.fetch_lead_items()
-
-    def fetch_lead_items(self):
-        try:
-            lead_doc = frappe.get_doc("Lead", self.lead)
-
-            if hasattr(lead_doc, "lead_material_details"):
-                self.set("feasible_material_details", [])  # Reset existing child table
-
-                for item in lead_doc.lead_material_details:
-                    self.append("feasible_material_details", {
-                        "material_type": item.material_type,
-                        "size": item.size,
-                        "brand": item.brand,
-                        "rate_range": item.rate_range,
-                        "image": item.image,
-                        "feasible": item.feasible,
-                        "quantity": item.quantity
-                    })
-        except Exception as e:
-            frappe.logger().error(f"Error in fetch_lead_items: {str(e)}")
-            frappe.throw(f"Error fetching lead items: {str(e)}")
+    pass
 
 @frappe.whitelist()
-def get_lead_material_details(lead_name):
-    """Fetch child table data from a selected Lead and return as JSON"""
-    try:
-        lead_doc = frappe.get_doc("Lead", lead_name)
+def map_lead_to_feasibility_check(source_name, target_doc=None):
+    """
+    Map fields from Lead Doctype to Feasibility Check Doctype,
+    including child table 'Material Details' -> 'Feasible Material Details'
+    """
+    def set_missing_values(source,target):
+        pass
 
-        material_details = []
-        if hasattr(lead_doc, "lead_material_details"):
-            for item in lead_doc.lead_material_details:
-                material_details.append({
-                    "material_type": item.material_type,
-                    "size": item.size,
-                    "brand": item.brand,
-                    "rate_range": item.rate_range,
-                    "image": item.image,
-                    "feasible": item.feasible,
-                    "quantity": item.quantity
-                })
+    target_doc = get_mapped_doc("Lead", source_name,
+        {
+            "Lead": {
+                "doctype": "Feasibility Check",
+                "field_map": {}
+            },
+            "Lead Material Details": { 
+                "doctype": "Lead Material Details",  
+                "field_map": {
+                    "material_type": "material_type",
+                    "size": "size",
+                    "brand": "brand",
+                    "rate_range": "rate_range",
+                    "image": "image",
+                    "feasible": "feasible",
+                    "quantity": "quantity"
+                },
+                "add_if_empty": True  
+            }
+        }, target_doc, set_missing_values)
 
-        return material_details
+    return target_doc
 
-    except Exception as e:
-        frappe.logger().error(f"Error fetching lead material details: {str(e)}")
-        frappe.throw(f"Error fetching lead material details: {str(e)}")
+# import frappe
+# from frappe.model.document import Document
+
+# class FeasibilityCheck(Document):
+#     def before_save(self):
+#         if self.lead:
+#             self.fetch_lead_items()
+
+#     def fetch_lead_items(self):
+#         try:
+#             lead_doc = frappe.get_doc("Lead", self.lead)
+
+#             if hasattr(lead_doc, "lead_material_details"):
+#                 self.set("feasible_material_details", [])  # Reset existing child table
+
+#                 for item in lead_doc.lead_material_details:
+#                     self.append("feasible_material_details", {
+#                         "material_type": item.material_type,
+#                         "size": item.size,
+#                         "brand": item.brand,
+#                         "rate_range": item.rate_range,
+#                         "image": item.image,
+#                         "feasible": item.feasible,
+#                         "quantity": item.quantity
+#                     })
+#         except Exception as e:
+#             frappe.logger().error(f"Error in fetch_lead_items: {str(e)}")
+#             frappe.throw(f"Error fetching lead items: {str(e)}")
+
+# @frappe.whitelist()
+# def get_lead_material_details(lead_name):
+#     """Fetch child table data from a selected Lead and return as JSON"""
+#     try:
+#         lead_doc = frappe.get_doc("Lead", lead_name)
+
+#         material_details = []
+#         if hasattr(lead_doc, "lead_material_details"):
+#             for item in lead_doc.lead_material_details:
+#                 material_details.append({
+#                     "material_type": item.material_type,
+#                     "size": item.size,
+#                     "brand": item.brand,
+#                     "rate_range": item.rate_range,
+#                     "image": item.image,
+#                     "feasible": item.feasible,
+#                     "quantity": item.quantity
+#                 })
+
+#         return material_details
+
+#     except Exception as e:
+#         frappe.logger().error(f"Error fetching lead material details: {str(e)}")
+#         frappe.throw(f"Error fetching lead material details: {str(e)}")
 
 
 

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -1,44 +1,99 @@
-# # # Copyright (c) 2025, efeone and contributors
-# #  # For license information, please see license.txt
+# # # # Copyright (c) 2025, efeone and contributors
+# # #  # For license information, please see license.txt
+
+# import frappe
+# from frappe.model.document import Document
+# from frappe.model.mapper import get_mapped_doc
+
+# class FeasibilityCheck(Document):
+#     pass
+
+# @frappe.whitelist()
+# def map_lead_to_feasibility_check(source_name, target_doc=None):
+#     """
+#     Map fields from Lead Doctype to Feasibility Check Doctype,
+#     including child table 'Material Details' -> 'Feasible Material Details'
+#     """
+#     def set_missing_values(source,target):
+#         pass
+
+#     target_doc = get_mapped_doc("Lead", source_name,
+#         {
+#             "Lead": {
+#                 "doctype": "Feasibility Check",
+#                 "field_map": {}
+#             },
+#             "Lead Material Details": { 
+#                 "doctype": "Lead Material Details",  
+#                 "field_map": {
+#                     "material_type": "material_type",
+#                     "size": "size",
+#                     "brand": "brand",
+#                     "rate_range": "rate_range",
+#                     "image": "image",
+#                     "feasible": "feasible",
+#                     "quantity": "quantity"
+#                 },
+#                 "add_if_empty": True  
+#             }
+#         }, target_doc, set_missing_values)
+
+#     return target_doc
 
 import frappe
 from frappe.model.document import Document
-from frappe.model.mapper import get_mapped_doc
 
 class FeasibilityCheck(Document):
-    pass
+    def before_save(self):
+        if self.lead:
+            self.fetch_lead_items()
+
+    def fetch_lead_items(self):
+        try:
+            lead_doc = frappe.get_doc("Lead", self.lead)
+
+            if hasattr(lead_doc, "lead_material_details"):
+                self.set("feasible_material_details", [])  # Reset existing child table
+
+                for item in lead_doc.lead_material_details:
+                    self.append("feasible_material_details", {
+                        "material_type": item.material_type,
+                        "size": item.size,
+                        "brand": item.brand,
+                        "rate_range": item.rate_range,
+                        "image": item.image,
+                        "feasible": item.feasible,
+                        "quantity": item.quantity
+                    })
+        except Exception as e:
+            frappe.logger().error(f"Error in fetch_lead_items: {str(e)}")
+            frappe.throw(f"Error fetching lead items: {str(e)}")
 
 @frappe.whitelist()
-def map_lead_to_feasibility_check(source_name, target_doc=None):
-    """
-    Map fields from Lead Doctype to Feasibility Check Doctype,
-    including child table 'Material Details' -> 'Feasible Material Details'
-    """
-    def set_missing_values(source,target):
-        pass
+def get_lead_material_details(lead_name):
+    """Fetch child table data from a selected Lead and return as JSON"""
+    try:
+        lead_doc = frappe.get_doc("Lead", lead_name)
 
-    target_doc = get_mapped_doc("Lead", source_name,
-        {
-            "Lead": {
-                "doctype": "Feasibility Check",
-                "field_map": {}
-            },
-            "Lead Material Details": { 
-                "doctype": "Lead Material Details",  
-                "field_map": {
-                    "material_type": "material_type",
-                    "size": "size",
-                    "brand": "brand",
-                    "rate_range": "rate_range",
-                    "image": "image",
-                    "feasible": "feasible",
-                    "quantity": "quantity"
-                },
-                "add_if_empty": True  
-            }
-        }, target_doc, set_missing_values)
+        material_details = []
+        if hasattr(lead_doc, "lead_material_details"):
+            for item in lead_doc.lead_material_details:
+                material_details.append({
+                    "material_type": item.material_type,
+                    "size": item.size,
+                    "brand": item.brand,
+                    "rate_range": item.rate_range,
+                    "image": item.image,
+                    "feasible": item.feasible,
+                    "quantity": item.quantity
+                })
 
-    return target_doc
+        return material_details
+
+    except Exception as e:
+        frappe.logger().error(f"Error fetching lead material details: {str(e)}")
+        frappe.throw(f"Error fetching lead material details: {str(e)}")
+
 
 
 

--- a/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
+++ b/versa_system/versa_system/doctype/feasibility_check/feasibility_check.py
@@ -1,5 +1,4 @@
- # Copyright (c) 2025, efeone and contributors
- # For license information, please see license.txt
+ 
 
 import frappe
 from frappe.model.document import Document
@@ -40,59 +39,6 @@ def map_lead_to_feasibility_check(source_name, target_doc=None):
 
     return target_doc
 
-# import frappe
-# from frappe.model.document import Document
-
-# class FeasibilityCheck(Document):
-#     def before_save(self):
-#         if self.lead:
-#             self.fetch_lead_items()
-
-#     def fetch_lead_items(self):
-#         try:
-#             lead_doc = frappe.get_doc("Lead", self.lead)
-
-#             if hasattr(lead_doc, "lead_material_details"):
-#                 self.set("feasible_material_details", [])  # Reset existing child table
-
-#                 for item in lead_doc.lead_material_details:
-#                     self.append("feasible_material_details", {
-#                         "material_type": item.material_type,
-#                         "size": item.size,
-#                         "brand": item.brand,
-#                         "rate_range": item.rate_range,
-#                         "image": item.image,
-#                         "feasible": item.feasible,
-#                         "quantity": item.quantity
-#                     })
-#         except Exception as e:
-#             frappe.logger().error(f"Error in fetch_lead_items: {str(e)}")
-#             frappe.throw(f"Error fetching lead items: {str(e)}")
-
-# @frappe.whitelist()
-# def get_lead_material_details(lead_name):
-#     """Fetch child table data from a selected Lead and return as JSON"""
-#     try:
-#         lead_doc = frappe.get_doc("Lead", lead_name)
-
-#         material_details = []
-#         if hasattr(lead_doc, "lead_material_details"):
-#             for item in lead_doc.lead_material_details:
-#                 material_details.append({
-#                     "material_type": item.material_type,
-#                     "size": item.size,
-#                     "brand": item.brand,
-#                     "rate_range": item.rate_range,
-#                     "image": item.image,
-#                     "feasible": item.feasible,
-#                     "quantity": item.quantity
-#                 })
-
-#         return material_details
-
-#     except Exception as e:
-#         frappe.logger().error(f"Error fetching lead material details: {str(e)}")
-#         frappe.throw(f"Error fetching lead material details: {str(e)}")
 
 
 

--- a/versa_system/versa_system/doctype/final_design/final_design.js
+++ b/versa_system/versa_system/doctype/final_design/final_design.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('Final Design', {
     refresh: function(frm) {
+    if(!frm.is_new())
         frm.add_custom_button(
             __("GoTo Material Check"),
             function () {

--- a/versa_system/versa_system/doctype/final_design/final_design.js
+++ b/versa_system/versa_system/doctype/final_design/final_design.js
@@ -1,5 +1,4 @@
-// Copyright (c) 2025, efeone and contributors
-// For license information, please see license.txt
+
 
 frappe.ui.form.on('Final Design', {
     refresh: function(frm) {

--- a/versa_system/versa_system/doctype/final_design/final_design.py
+++ b/versa_system/versa_system/doctype/final_design/final_design.py
@@ -1,47 +1,4 @@
-# # Copyright (c) 2025, efeone and contributors
-# # For license information, please see license.txt
 
-# import frappe
-# from frappe.model.document import Document
-# from frappe.model.mapper import get_mapped_doc
-
-# class FinalDesign(Document):
-#     pass
-
-# @frappe.whitelist()
-# def map_quotation_to_final_design(source_name, target_doc=None):
-    
-#     def set_missing_values(source, target):
-#         pass 
-
-#     target_doc = get_mapped_doc(
-#         "Quotation", source_name,
-#         {
-#             "Quotation": {
-#                 "doctype": "Final Design",
-#                 "field_map": {}
-                
-#             },
-#             "Lead Material Details": {  
-#                 "doctype": "Lead Material Details",  
-#                 "field_map": {
-#                     "material_type": "material_type",
-#                     # "size": "size",
-#                     # "brand": "brand",
-#                     # "rate_range": "rate_range",
-#                     "image": "image",
-#                     # "feasible": "feasible",
-#                     "quantity": "quantity"
-#                 },class FinalDesign(Document):
-
-#                 "add_if_empty": True 
-#             }
-#         },
-#         target_doc,  
-#         set_missing_values  
-#     )
-
-#     return target_doc
 import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc

--- a/versa_system/versa_system/doctype/final_design/final_design.py
+++ b/versa_system/versa_system/doctype/final_design/final_design.py
@@ -1,12 +1,73 @@
-# Copyright (c) 2025, efeone and contributors
-# For license information, please see license.txt
+# # Copyright (c) 2025, efeone and contributors
+# # For license information, please see license.txt
 
+# import frappe
+# from frappe.model.document import Document
+# from frappe.model.mapper import get_mapped_doc
+
+# class FinalDesign(Document):
+#     pass
+
+# @frappe.whitelist()
+# def map_quotation_to_final_design(source_name, target_doc=None):
+    
+#     def set_missing_values(source, target):
+#         pass 
+
+#     target_doc = get_mapped_doc(
+#         "Quotation", source_name,
+#         {
+#             "Quotation": {
+#                 "doctype": "Final Design",
+#                 "field_map": {}
+                
+#             },
+#             "Lead Material Details": {  
+#                 "doctype": "Lead Material Details",  
+#                 "field_map": {
+#                     "material_type": "material_type",
+#                     # "size": "size",
+#                     # "brand": "brand",
+#                     # "rate_range": "rate_range",
+#                     "image": "image",
+#                     # "feasible": "feasible",
+#                     "quantity": "quantity"
+#                 },class FinalDesign(Document):
+
+#                 "add_if_empty": True 
+#             }
+#         },
+#         target_doc,  
+#         set_missing_values  
+#     )
+
+#     return target_doc
 import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
 class FinalDesign(Document):
-    pass
+
+    def before_save(self):
+        if self.lead:
+            self.fetch_lead_items()
+
+    def fetch_lead_items(self):
+        # Fetch Lead document
+        lead_doc = frappe.get_doc("Lead", self.lead)
+
+        # Clear existing items in the child table
+        self.set("items", [])
+
+        # Check if the lead has a child table named 'lead_material_details'
+        if hasattr(lead_doc, "lead_material_details"):
+            for item in lead_doc.lead_material_details:
+                self.append("items", {
+                    "material_type": item.material_type,
+                    "image": item.image,
+                    "quantity": item.quantity
+                })
+
 
 @frappe.whitelist()
 def map_quotation_to_final_design(source_name, target_doc=None):
@@ -17,20 +78,15 @@ def map_quotation_to_final_design(source_name, target_doc=None):
     target_doc = get_mapped_doc(
         "Quotation", source_name,
         {
-            "Quotation": {
+            "Quotation": {  
                 "doctype": "Final Design",
                 "field_map": {}
-                
             },
             "Lead Material Details": {  
                 "doctype": "Lead Material Details",  
                 "field_map": {
                     "material_type": "material_type",
-                    # "size": "size",
-                    # "brand": "brand",
-                    # "rate_range": "rate_range",
                     "image": "image",
-                    # "feasible": "feasible",
                     "quantity": "quantity"
                 },
                 "add_if_empty": True 
@@ -41,4 +97,5 @@ def map_quotation_to_final_design(source_name, target_doc=None):
     )
 
     return target_doc
+
 

--- a/versa_system/versa_system/doctype/item_size_chart/item_size_chart.py
+++ b/versa_system/versa_system/doctype/item_size_chart/item_size_chart.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 

--- a/versa_system/versa_system/doctype/material_check/material_check.js
+++ b/versa_system/versa_system/doctype/material_check/material_check.js
@@ -1,8 +1,30 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
+frappe.ui.form.on("Material Check", {
+	refresh(frm) {
+        frm.add_custom_button(
+            __("Material Request"),
+            function () {
+                frappe.set_route("Form", "Material Request", "new-material-request");
+            }
+        );
+        frm.add_custom_button(
+            __("Work Order"),
+            function () {
+                frappe.set_route("Form", "Work Order", "new-material-request","New Work Order");
+            }
+        );
+	},
+});
+
 // frappe.ui.form.on("Material Check", {
 // 	refresh(frm) {
-
+//         frm.add_custom_button(
+//             __("Work Order"),
+//             function () {
+//                 frappe.set_route("Form", "Work Order", "new-material-request","New Work Order");
+//             }
+//         );
 // 	},
 // });

--- a/versa_system/versa_system/doctype/material_check/material_check.js
+++ b/versa_system/versa_system/doctype/material_check/material_check.js
@@ -18,13 +18,3 @@ frappe.ui.form.on("Material Check", {
 	},
 });
 
-// frappe.ui.form.on("Material Check", {
-// 	refresh(frm) {
-//         frm.add_custom_button(
-//             __("Work Order"),
-//             function () {
-//                 frappe.set_route("Form", "Work Order", "new-material-request","New Work Order");
-//             }
-//         );
-// 	},
-// });

--- a/versa_system/versa_system/doctype/material_check/material_check.json
+++ b/versa_system/versa_system/doctype/material_check/material_check.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:MC-{YY}-{####}",
  "creation": "2025-02-25 22:29:41.601797",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -17,10 +18,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-25 23:46:15.548259",
+ "modified": "2025-02-27 23:44:12.774258",
  "modified_by": "Administrator",
  "module": "Versa System",
  "name": "Material Check",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/versa_system/versa_system/doctype/material_check/material_check.py
+++ b/versa_system/versa_system/doctype/material_check/material_check.py
@@ -27,11 +27,11 @@ def final_design_to_material_check(source_name, target_doc=None):
                 "doctype": "Lead Material Details",  
                 "field_map": {
                     "material_type": "material_type",
-                    # "size": "size",
-                    # "brand": "brand",
-                    # "rate_range": "rate_range",
-                    # "image": "image",
-                    # "feasible": "feasible",
+                    "size": "size",
+                    "brand": "brand",
+                    "rate_range": "rate_range",
+                    "image": "image",
+                    "feasible": "feasible",
                     "quantity": "quantity"
                 },
                 "add_if_empty": True 

--- a/versa_system/versa_system/doctype/moc_design/moc_design.js
+++ b/versa_system/versa_system/doctype/moc_design/moc_design.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("MOC Design", {
 	refresh(frm) {
-    if (!frm.is_new()) { // Ensure the button appears only after saving
+    if (frm.doc.workflow_state === "Approved") { // Ensure the button appears only after saving
         frm.add_custom_button(
             __("GoTo Quotation"),
             function () {


### PR DESCRIPTION
## Feature description
added Profoma Invoice status in sales order
## Solution description
Created setup.py file and added code to get proforma invoice through property setter . by using hooks connected with core doctype and added code on sales order.py file
## Output
![Screenshot from 2025-03-02 22-45-34](https://github.com/user-attachments/assets/c44630f5-c898-4bc3-80af-14a2be8c8798)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Chrome